### PR TITLE
fix(tests): repo-relative paths in stat-card tests + guard against absolute paths

### DIFF
--- a/tests/test_no_hardcoded_paths.py
+++ b/tests/test_no_hardcoded_paths.py
@@ -1,0 +1,53 @@
+"""Regression guard: test files must not contain hardcoded absolute filesystem paths.
+
+Absolute paths (e.g. /opt/, /home/, /Users/) tie tests to a specific dev box and
+cause FileNotFoundError on any other runner. All paths must be constructed relative
+to PROJECT_ROOT = Path(__file__).resolve().parent.parent or equivalent.
+"""
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# Patterns that indicate a hardcoded absolute path in a string literal.
+# Match /opt/, /home/, or /Users/ inside a quoted string.
+_ABS_PATH_PATTERN = re.compile(r"""["'](/opt/|/home/|/Users/)""")
+
+# Allowlist: lines that contain these substrings are mock/stub values, not real
+# filesystem access, and should not be flagged.
+_MOCK_CONTEXTS = (
+    "return_value=",
+    "side_effect=",
+    "patch(",
+    "monkeypatch",
+    "# mock",
+    "# fake",
+    "# stub",
+)
+
+
+def _collect_violations() -> list[str]:
+    violations: list[str] = []
+    for test_file in sorted(TESTS_DIR.glob("*.py")):
+        text = test_file.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _ABS_PATH_PATTERN.search(line) and not any(
+                ctx in line for ctx in _MOCK_CONTEXTS
+            ):
+                violations.append(f"{test_file.name}:{lineno}: {line.strip()}")
+    return violations
+
+
+def test_no_hardcoded_absolute_paths_in_tests():
+    """No test file may contain a hardcoded absolute filesystem path literal.
+
+    Use PROJECT_ROOT = Path(__file__).resolve().parent.parent and build paths
+    relative to that, matching the pattern in test_dashboard_auth.py and
+    test_csp_security.py.
+    """
+    violations = _collect_violations()
+    assert not violations, (
+        "Hardcoded absolute paths found in test files — use PROJECT_ROOT-relative paths:\n"
+        + "\n".join(violations)
+    )

--- a/tests/test_no_hardcoded_paths.py
+++ b/tests/test_no_hardcoded_paths.py
@@ -32,9 +32,7 @@ def _collect_violations() -> list[str]:
     for test_file in sorted(TESTS_DIR.glob("*.py")):
         text = test_file.read_text(encoding="utf-8")
         for lineno, line in enumerate(text.splitlines(), start=1):
-            if _ABS_PATH_PATTERN.search(line) and not any(
-                ctx in line for ctx in _MOCK_CONTEXTS
-            ):
+            if _ABS_PATH_PATTERN.search(line) and not any(ctx in line for ctx in _MOCK_CONTEXTS):
                 violations.append(f"{test_file.name}:{lineno}: {line.strip()}")
     return violations
 
@@ -48,6 +46,5 @@ def test_no_hardcoded_absolute_paths_in_tests():
     """
     violations = _collect_violations()
     assert not violations, (
-        "Hardcoded absolute paths found in test files — use PROJECT_ROOT-relative paths:\n"
-        + "\n".join(violations)
+        "Hardcoded absolute paths found in test files — use PROJECT_ROOT-relative paths:\n" + "\n".join(violations)
     )

--- a/tests/test_super_innovation.py
+++ b/tests/test_super_innovation.py
@@ -10,6 +10,7 @@ Fix:
 3. Build specific taglines from component concept terms
 """
 
+from pathlib import Path
 from project_forge.engine.super_ideas import (
     _build_super_tagline,
     _dynamic_cluster_name,
@@ -18,6 +19,8 @@ from project_forge.engine.super_ideas import (
     synthesize_super_idea,
 )
 from project_forge.models import Idea, IdeaCategory
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _make_idea(
@@ -304,7 +307,7 @@ class TestStatCardIntegrity:
         This tests the template logic — stats.super_ideas (from DB COUNT query)
         must be what feeds the stat-number element, not ns.active_super.
         """
-        template_path = "/opt/vmdata/project-forge/src/project_forge/web/templates/dashboard.html"
+        template_path = PROJECT_ROOT / "src/project_forge/web/templates/dashboard.html"
         with open(template_path) as f:
             content = f.read()
         # The stat-number for Super Ideas must use stats.super_ideas
@@ -316,7 +319,7 @@ class TestStatCardIntegrity:
 
     def test_js_updates_contributed_not_avg_score_at_index_4(self):
         """JS numbers[4] must update the Contributed card, not Avg Score."""
-        js_path = "/opt/vmdata/project-forge/src/project_forge/web/static/app.js"
+        js_path = PROJECT_ROOT / "src/project_forge/web/static/app.js"
         with open(js_path) as f:
             content = f.read()
         # numbers[4] must reference contributed, not avg_feasibility_score
@@ -328,7 +331,7 @@ class TestStatCardIntegrity:
 
     def test_js_updates_avg_score_at_index_5(self):
         """JS must update the Avg Score card at numbers[5]."""
-        js_path = "/opt/vmdata/project-forge/src/project_forge/web/static/app.js"
+        js_path = PROJECT_ROOT / "src/project_forge/web/static/app.js"
         with open(js_path) as f:
             content = f.read()
         assert "numbers[5].textContent = stats.avg_feasibility_score" in content, (

--- a/tests/test_super_innovation.py
+++ b/tests/test_super_innovation.py
@@ -11,6 +11,7 @@ Fix:
 """
 
 from pathlib import Path
+
 from project_forge.engine.super_ideas import (
     _build_super_tagline,
     _dynamic_cluster_name,


### PR DESCRIPTION
## Root cause
`tests/test_super_innovation.py::TestStatCardIntegrity` opened 3 files via hardcoded absolute paths under `/opt/vmdata/project-forge/...` (a dev checkout). CI checks out into the runner workspace, so when the `[self-hosted, Linux]` round-robin landed the `test` job on **rocky** (no such path) the tests raised `FileNotFoundError` and failed — the apparent 'intermittency' was runner roulette. Worse, even when green on the dev box they asserted against the dev working copy, not the commit under test (fake-green).

## Fix
Use `PROJECT_ROOT = Path(__file__).resolve().parent.parent` and repo-relative paths — matching the pattern already used in `test_dashboard_auth.py` / `test_csp_security.py`. No production code change; the assertions hold against the real templates/app.js.

## Reciprocal guard
New `tests/test_no_hardcoded_paths.py` fails if any test file contains an absolute filesystem path literal (`/opt/`, `/home/`, `/Users/`) — so a test can never again read outside the CI checkout.

🤖 Generated with Claude Code