### PR TITLE
[Mechanic] Prune Stale Rate-Limit Keys

### DIFF
--- a/src/project_forge/web/routes.py
+++ b/src/project_forge/web/routes.py
@@ -2112,14 +2112,30 @@ class IssueReport(BaseModel):
 
 _RATE_LIMIT_WINDOW = 60
 _RATE_LIMIT_MAX = 5
+# Evict fully-expired keys once the store grows past this. Without it the
+# store leaks one dead entry for every (client-ip, action) pair ever seen —
+# unbounded growth in a long-running process (a2923634 "Prune Stale
+# Rate-Limit Keys").
+_RATE_LIMIT_PRUNE_THRESHOLD = 1024
 _rate_limit_store: dict[str, list[float]] = {}
+
+
+def _prune_rate_limit_store(now: float) -> None:
+    """Drop keys whose every timestamp has aged out of the window."""
+    stale = [key for key, ts in _rate_limit_store.items() if all(now - t >= _RATE_LIMIT_WINDOW for t in ts)]
+    for key in stale:
+        del _rate_limit_store[key]
 
 
 def _check_rate_limit(client_key: str) -> None:
     """Raise 429 if the client has exceeded the issue creation rate limit."""
     now = time.monotonic()
-    timestamps = _rate_limit_store.get(client_key, [])
-    timestamps = [t for t in timestamps if now - t < _RATE_LIMIT_WINDOW]
+    # Opportunistically evict expired keys so the store can't grow unbounded.
+    # Only sweeps when it has actually grown large, so the common path stays
+    # O(1).
+    if len(_rate_limit_store) > _RATE_LIMIT_PRUNE_THRESHOLD:
+        _prune_rate_limit_store(now)
+    timestamps = [t for t in _rate_limit_store.get(client_key, []) if now - t < _RATE_LIMIT_WINDOW]
     if len(timestamps) >= _RATE_LIMIT_MAX:
         raise HTTPException(status_code=429, detail="Rate limit exceeded. Try again in a minute.")
     timestamps.append(now)

--- a/tests/test_routes_rate_limit.py
+++ b/tests/test_routes_rate_limit.py
@@ -126,6 +126,60 @@ class TestIngestRateLimit:
         assert statuses[0] == 200
 
 
+class TestRateLimitEviction:
+    """a2923634 — the store must not grow unbounded; fully-expired keys are
+    evicted so a long-running process doesn't leak an entry per client/action."""
+
+    def test_prune_drops_expired_keeps_fresh(self):
+        import time
+
+        from project_forge.web.routes import (
+            _RATE_LIMIT_WINDOW,
+            _prune_rate_limit_store,
+            _rate_limit_store,
+        )
+
+        now = time.monotonic()
+        _rate_limit_store["stale:1"] = [now - _RATE_LIMIT_WINDOW - 5]
+        _rate_limit_store["stale:2"] = [now - _RATE_LIMIT_WINDOW - 1, now - _RATE_LIMIT_WINDOW - 2]
+        _rate_limit_store["fresh:1"] = [now - 1]
+
+        _prune_rate_limit_store(now)
+
+        assert "stale:1" not in _rate_limit_store
+        assert "stale:2" not in _rate_limit_store
+        assert "fresh:1" in _rate_limit_store
+
+    def test_check_rate_limit_evicts_once_store_is_large(self):
+        import time
+
+        from project_forge.web import routes
+
+        now = time.monotonic()
+        for i in range(routes._RATE_LIMIT_PRUNE_THRESHOLD + 50):
+            routes._rate_limit_store[f"stale:{i}"] = [now - routes._RATE_LIMIT_WINDOW - 10]
+        before = len(routes._rate_limit_store)
+
+        routes._check_rate_limit("liveclient:probe")
+
+        after = len(routes._rate_limit_store)
+        assert after < before, "expired keys should have been evicted"
+        assert "liveclient:probe" in routes._rate_limit_store, "the live key must remain"
+
+    def test_active_limiting_still_enforced(self):
+        """Eviction must not weaken the limiter — a burst still trips 429."""
+        import pytest as _pytest
+        from fastapi import HTTPException
+
+        from project_forge.web.routes import _RATE_LIMIT_MAX, _check_rate_limit
+
+        for _ in range(_RATE_LIMIT_MAX):
+            _check_rate_limit("burst:client")
+        with _pytest.raises(HTTPException) as exc:
+            _check_rate_limit("burst:client")
+        assert exc.value.status_code == 429
+
+
 class TestRateLimitIsolation:
     @pytest.mark.asyncio
     async def test_unrelated_get_still_passes(self, client):


### PR DESCRIPTION
Autonomous self-improvement for Think Tank item `a2923634f17b`.

**Problem:** `_rate_limit_store` grew unbounded — one dead entry per (client-ip, action) ever seen, never evicted after the window expired.

**Fix:** `_prune_rate_limit_store()` drops keys whose timestamps have all aged out; `_check_rate_limit` sweeps opportunistically once the store passes a threshold (common path stays O(1)). Active rate-limiting is unchanged — verified by test.

Tests: +TestRateLimitEviction (prune drops-expired/keeps-fresh, check evicts when large, active limiting still 429s). Review + merge to ship.

Generated with Claude Code