### PR TITLE
[Mechanic] Sanitize Request ID Header

### DIFF
--- a/src/project_forge/web/app.py
+++ b/src/project_forge/web/app.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -76,12 +77,24 @@ templates.env.globals["dashboard_token"] = _dashboard_token
 
 _CSP_SKIP_PATHS = ("/docs", "/redoc", "/openapi.json")
 
+# Client-supplied request IDs are untrusted input reflected into a response
+# header, so restrict them to a short, safe alphabet. Anything else (missing,
+# too long, control characters, non-ASCII) is replaced with a fresh ID.
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def sanitize_request_id(value: str | None) -> str:
+    """Return `value` if it is a safe request ID, else a freshly generated one."""
+    if value is not None and _REQUEST_ID_RE.match(value):
+        return value
+    return uuid.uuid4().hex[:16]
+
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Add a unique X-Request-ID to every response for correlation."""
 
     async def dispatch(self, request: Request, call_next):
-        request_id = request.headers.get("x-request-id", uuid.uuid4().hex[:16])
+        request_id = sanitize_request_id(request.headers.get("x-request-id"))
         response: Response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response

--- a/tests/test_request_id_sanitize.py
+++ b/tests/test_request_id_sanitize.py
@@ -1,0 +1,75 @@
+"""Request ID sanitization — client-supplied X-Request-ID must be validated."""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from project_forge.web.app import app, db, sanitize_request_id
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    db.db_path = tmp_path / "test_request_id.db"
+    await db.connect()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    await db.close()
+
+
+SAFE_DEFAULT_CHARS = set("0123456789abcdef")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "a" * 65,
+        "has space",
+        "inject\r\nX-Evil: 1",
+        "café",
+        "semi;colon",
+        "\x00nul",
+    ],
+)
+def test_sanitize_rejects_bad_values(value):
+    """Missing, over-long, or non-alphanumeric IDs are replaced with a fresh one."""
+    result = sanitize_request_id(value)
+    assert result != value
+    assert len(result) == 16
+    assert set(result) <= SAFE_DEFAULT_CHARS
+
+
+@pytest.mark.parametrize("value", ["abc123", "A-B_c", "x", "9" * 64])
+def test_sanitize_accepts_good_values(value):
+    """Well-formed client IDs are preserved for correlation."""
+    assert sanitize_request_id(value) == value
+
+
+@pytest.mark.asyncio
+async def test_malicious_request_id_not_reflected(client):
+    """A header-injection payload must not be echoed back."""
+    resp = await client.get("/health", headers={"X-Request-ID": "aaa\r\nX-Evil: 1"})
+    assert resp.status_code == 200
+    echoed = resp.headers["X-Request-ID"]
+    assert "X-Evil" not in echoed
+    assert "\r" not in echoed
+    assert "\n" not in echoed
+    assert len(echoed) == 16
+
+
+@pytest.mark.asyncio
+async def test_oversized_request_id_capped(client):
+    """A multi-KB request ID is discarded, not reflected."""
+    resp = await client.get("/health", headers={"X-Request-ID": "z" * 4096})
+    assert resp.status_code == 200
+    assert len(resp.headers["X-Request-ID"]) == 16
+
+
+@pytest.mark.asyncio
+async def test_valid_request_id_preserved(client):
+    """A well-formed client ID still round-trips for correlation."""
+    resp = await client.get("/health", headers={"X-Request-ID": "trace-abc_123"})
+    assert resp.status_code == 200
+    assert resp.headers["X-Request-ID"] == "trace-abc_123"


### PR DESCRIPTION
Autonomous implementation of Think Tank item `b9e6505630e6`.

Client-supplied X-Request-ID header is reflected unsanitized, risking log/header injection and crashes.

Review + merge to ship.