### PR TITLE
feat(pki): adversarial depth + prior-art gate, and close the board's back door

### DIFF
--- a/src/project_forge/cron/auto_scan.py
+++ b/src/project_forge/cron/auto_scan.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from project_forge.engine.categories import CATEGORY_SEEDS, COMBINATORIC_TEMPLATES, CONTRARIAN_PROMPTS
 from project_forge.engine.dedup import filter_and_save
 from project_forge.engine.quality_review import review_idea
-from project_forge.models import GenerationRun, Idea, IdeaCategory
+from project_forge.models import GATED_CATEGORIES, GenerationRun, Idea, IdeaCategory
 from project_forge.storage.db import Database
 
 logger = logging.getLogger(__name__)
@@ -478,7 +478,11 @@ def generate_local_idea(
     if category is None:
         # SELF_IMPROVEMENT is generated only by the introspection engine, never
         # by the generic combinatoric path (which produces garbled SI names).
-        category = random.choice([c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT])
+        # GATED_CATEGORIES are excluded for the same reason: their board only
+        # shows what its own gated cadence produced.
+        category = random.choice(
+            [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT and c not in GATED_CATEGORIES]
+        )
 
     seeds = CATEGORY_SEEDS[category]
     concepts = seeds["seed_concepts"]
@@ -582,7 +586,7 @@ async def run_auto_scan(db: Database, count: int = 5) -> list[Idea]:
         IdeaCategory.VULNERABILITY_RESEARCH,
         IdeaCategory.COMPLIANCE,
     }
-    categories = [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT]
+    categories = [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT and c not in GATED_CATEGORIES]
     random.shuffle(categories)
     security_extra = [c for c in categories if c in security_core]
     random.shuffle(security_extra)

--- a/src/project_forge/cron/horizontal.py
+++ b/src/project_forge/cron/horizontal.py
@@ -15,7 +15,7 @@ from project_forge.engine.llm_generator import generate_idea_llm
 from project_forge.engine.quality_review import review_idea
 from project_forge.engine.saturation import category_density, rank_pair_score
 from project_forge.engine.super_ideas import SuperIdeaGenerator, pick_least_covered_slot
-from project_forge.models import Idea, IdeaCategory
+from project_forge.models import GATED_CATEGORIES, Idea, IdeaCategory
 from project_forge.storage.db import Database
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ async def pick_cross_category_pair(
         return IdeaCategory(best[1]), IdeaCategory(best[2])
 
     # Fallback: random pair (should never reach here with 600+ pairs)
-    cats = [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT]
+    cats = [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT and c not in GATED_CATEGORIES]
     a, b = random.sample(cats, 2)
     return a, b
 

--- a/src/project_forge/cron/scheduler.py
+++ b/src/project_forge/cron/scheduler.py
@@ -13,14 +13,17 @@ from project_forge.engine.quality_review import review_idea
 from project_forge.engine.scorer import is_high_value, score_idea
 from project_forge.feeds import get_external_seeds
 from project_forge.feeds.cache import FeedCache
-from project_forge.models import GenerationRun, Idea, IdeaCategory
+from project_forge.models import GATED_CATEGORIES, GenerationRun, Idea, IdeaCategory
 from project_forge.scaffold.builder import build_scaffold_spec, render_scaffold
 from project_forge.scaffold.github import create_issue, create_label, create_repo, push_initial_commit
 from project_forge.storage.db import Database
 
 logger = logging.getLogger(__name__)
 
-ALL_CATEGORIES = list(IdeaCategory)
+# Gated categories are excluded: their board admits only what its own cadence
+# produced, so generating into them here just makes pool noise the board will
+# never surface. See GATED_CATEGORIES in models.py.
+ALL_CATEGORIES = [c for c in IdeaCategory if c not in GATED_CATEGORIES]
 
 
 def _feeds_dir() -> Path:
@@ -101,8 +104,8 @@ def _create_enhancement_issue(repo: str, idea: Idea, reason: str) -> str:
 async def generate_and_store(db: Database, generator: IdeaGenerator) -> Idea:
     """Generate one idea, score it, route it, and store it."""
     category = await pick_category(db)
-    recent_ideas_objs = await db.list_ideas(limit=5)
-    recent_names = [i.name for i in recent_ideas_objs]
+    recent_ideas_objs = await db.list_ideas(limit=10)
+    recent_names = [f"{i.name}: {i.tagline}" for i in recent_ideas_objs]
 
     # Alternate between prompt modes for variety
     run_count = await db.count_ideas()

--- a/src/project_forge/engine/pki.py
+++ b/src/project_forge/engine/pki.py
@@ -285,14 +285,21 @@ def admits(idea: Idea, score: float) -> tuple[bool, str]:
 
 async def score_pending_pki_urgency(db: Database, limit: int = 50) -> dict[str, Any]:
     """Score active PKI-board ideas that don't yet have a pki_urgency_score.
-    Scoped to PKI_CATEGORIES — the axis is the board's ranking, not a
-    universal property. Also back-fills `pki_anchor` when the prose cites
-    one. Idempotent; returns a summary."""
+
+    Scoped to PKI_CATEGORIES *and* `generation_mode = 'pki'` — the axis is the
+    board's ranking, not a universal property, and a score is what puts an
+    idea on the board. Without the mode filter this cadence was the back
+    door: it scored every PKI-category idea the ordinary rotation produced,
+    putting ungated content on a board that advertises a hard admission gate.
+
+    Also back-fills `pki_anchor` when the prose cites one. Idempotent;
+    returns a summary."""
     placeholders = ",".join("?" * len(PKI_CATEGORIES))
     cur = await db.db.execute(
         f"SELECT id FROM ideas "  # noqa: S608
         f"WHERE pki_urgency_score IS NULL "
         f"AND category IN ({placeholders}) "
+        f"AND generation_mode = 'pki' "
         f"AND status NOT IN ('archived', 'rejected') "
         f"ORDER BY generated_at DESC LIMIT ?",
         (*[c.value for c in PKI_CATEGORIES], limit),

--- a/src/project_forge/engine/pki_depth.py
+++ b/src/project_forge/engine/pki_depth.py
@@ -1,0 +1,516 @@
+"""Multi-pass depth engine for the PKI board — effort, not just selectivity.
+
+`engine/pki.py` decides WHETHER a finding reaches /pki. This module decides
+whether it is worth READING once it does.
+
+The admission gate is strong, but everything it admits is still one LLM
+call: a paragraph that sounds right, cites an RFC, and that a CA engineer
+would nonetheless not act on, because nobody ever tried to break it. So we
+break it ourselves, three ways, before it lands:
+
+    real   — is the problem real, is the mechanism correctly characterized
+    solved — does existing tooling / an existing standard already handle it
+    wrong  — is there a factual or protocol-level error in it
+
+Each lens is a SEPARATE call with its own adversarial prompt. A lens is not
+asked to be balanced; it is asked to find the flaw. Then one revise pass
+rewrites the draft to answer what survived and to state its own strongest
+remaining counterargument out loud. Up to four calls per admitted item —
+cheap, because the board admits roughly one item every few hours.
+
+The panel can also kill: a fatal `solved` hit means someone already built
+it, and two high-severity hits anywhere mean the draft is not salvageable
+by rewording. The cadence drops those.
+
+Two things keep this from being theatre rather than scrutiny:
+
+  - The `solved` lens is handed the prior-art search results, so it is
+    ADJUDICATING named repositories that demonstrably exist instead of
+    recalling tool names from weights. Recall is the prompt shape that
+    invents a plausible tool and kills a good idea with it; adjudication
+    is checkable.
+  - The `wrong` lens must cite the spec it is correcting. An uncited
+    factual objection is an assertion, and is demoted to a nit rather
+    than allowed to count toward a kill.
+
+Keyless is the floor, as everywhere else in this engine: with no cheap
+backend we make zero calls and hand the idea straight back. The board must
+work with no LLM and no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from project_forge.engine.llm_backend import resolve_cheap_backend
+from project_forge.models import Idea
+
+logger = logging.getLogger(__name__)
+
+
+# The three attack angles. Order is the order they run in and is stable so
+# the prompts (and any downstream logging) stay comparable across fires.
+LENSES: tuple[str, str, str] = ("real", "solved", "wrong")
+
+# What counts as a landed hit rather than a nit. Tuned high on purpose: an
+# adversarial prompt will always find *something*, and a board that kills on
+# 0.4-severity quibbles would never publish.
+HIGH_SEVERITY = 0.70
+
+# Two landed hits across lenses means the draft is wrong in more than one
+# dimension — a rewrite would be inventing a different idea, not sharpening
+# this one.
+KILL_OBJECTION_COUNT = 2
+
+# The lens that kills on its own. "Already solved" is fatal in a way the
+# others are not: a mischaracterized mechanism can be corrected by the
+# revise pass, but an existing tool cannot be revised away.
+FATAL_LENS = "solved"
+
+# A unilateral veto needs a higher bar than a vote. The prompt's own rubric
+# says 0.7-0.9 is "a serious problem the author must answer" and only 0.9+ is
+# "should not exist as written" — and the `solved` brief explicitly invites
+# the partial answer ("say exactly which part is already covered"), which is
+# what lands at 0.7-0.8. Every PKI idea has partial prior coverage. Reading
+# 0.70 as unsalvageable emptied the board on the expected case.
+FATAL_SEVERITY = 0.90
+
+# An objection under this is a nit. It may still inform the rewrite, but it
+# is never surfaced on the card as "the strongest counterargument" — a 0.05
+# quibble presented as the headline objection is exactly the noise this
+# board exists to avoid.
+OBJECTION_DISPLAY_FLOOR = 0.40
+
+# The `wrong` lens claims a factual error. Without a citation that is an
+# assertion, not a correction, so it is capped at nit severity: it still
+# reaches the rewrite, but it cannot vote toward a kill and cannot be shown
+# as the headline objection.
+UNCITED_SEVERITY_CAP = 0.35
+
+# Prior-art repos shown to the `solved` lens. More than this and the prompt
+# turns into a directory listing the model skims.
+MAX_PRIOR_ART_SHOWN = 5
+
+# Fields the revise pass is allowed to rewrite. Everything else — id,
+# category, content_hash, scores, timestamps — is identity and survives
+# untouched, so a revision can never fork the idea or orphan its dedup key.
+REVISABLE_FIELDS = ("name", "tagline", "description", "mvp_scope", "market_analysis")
+
+# Guard against a model that "revises" by returning a single word or a
+# novel. Both shapes are corruption; fall back to the original instead.
+_MIN_FIELD_LEN = 8
+_MAX_FIELD_LEN = 8000
+
+# Placeholder text models emit when a lens finds nothing. Not an objection.
+_NULL_OBJECTIONS = {"none", "n/a", "na", "no objection", "no objections", "null"}
+
+
+@dataclass
+class Objection:
+    """One lens's best shot at the draft."""
+
+    lens: str
+    severity: float
+    text: str
+
+
+@dataclass
+class DepthResult:
+    """Outcome of the panel plus revise pass.
+
+    `idea` is the REVISED idea when the draft survived and the revision
+    parsed, and the original object otherwise — callers can rely on getting
+    a usable Idea back in every case, including keyless."""
+
+    idea: Idea
+    objections: list[Objection] = field(default_factory=list)
+    strongest: str | None = None
+    survived: bool = True
+    passes: int = 0
+    revised: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# prompts                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+_LENS_BRIEF: dict[str, str] = {
+    "real": (
+        "ATTACK THE PREMISE. Is this problem actually real, and is the "
+        "mechanism correctly characterized? If the draft describes a failure "
+        "mode that does not occur in practice, or attributes it to the wrong "
+        "cause, say so and name the specific technical error. Do not comment "
+        "on novelty or on implementation detail — only on whether the problem "
+        "and its mechanism are real as stated."
+    ),
+    "solved": (
+        "ATTACK THE NOVELTY. Is this already adequately handled by existing "
+        "tooling, an existing standard, or a trivial workaround? Name the "
+        "specific tool, RFC, CA/Browser Forum requirement, library, or "
+        "one-liner that solves it. If candidate prior art is listed below, "
+        "adjudicate it: say which listed project does this job and which "
+        "merely shares the vocabulary. Do NOT name a tool you are not "
+        "confident exists — an invented tool name is worse than no "
+        "objection, because it kills real work. If the coverage is only "
+        "partial, say exactly which part is already covered, and treat "
+        "partial coverage as a problem to answer (0.7-0.85), not as fatal. "
+        "Do not comment on whether the problem is real — assume it is."
+    ),
+    "wrong": (
+        "ATTACK THE CORRECTNESS. Is there a factual or protocol-level error "
+        "here — wrong key or signature sizes, wrong protocol layer, wrong "
+        "threat model, a misread of the cited spec, a confusion between "
+        "revocation transports, an algorithm that does not do what the draft "
+        "says it does? Quote the erroneous claim and state what is actually "
+        "true. If the draft states a size, count, or bandwidth figure, "
+        "recompute it from first principles and show the arithmetic — "
+        "entries x bytes per entry, signatures x signature size — in your "
+        "objection. A recomputation that differs by more than 2x is severity "
+        "0.7 or higher. Every correction MUST carry a citation: the exact "
+        "document and location that establishes what is true (for example "
+        "'FIPS 204 Table 2', 'RFC 5280 s5.2.5', 'CA/BF BR 4.9.7'). An "
+        "uncited correction is treated as a nit no matter how confident it "
+        "sounds. Do not comment on novelty or on whether the problem matters."
+    ),
+}
+
+# One worked example per lens. Self-reported severity means nothing without
+# a calibration anchor — without these the modal reply is a mid-severity
+# generic remark that trips no threshold and teaches nobody.
+_SEVERITY_ANCHORS: dict[str, str] = {
+    "real": (
+        "Calibration: 'CRLs are not fetched by browsers at all any more, so "
+        "the described outage cannot happen' is 0.9 — the premise does not "
+        "occur. 'The draft says operators size shards by hand; large CAs "
+        "mostly script it' is 0.3 — true, and it changes nothing."
+    ),
+    "solved": (
+        "Calibration: 'crlite ships exactly this filter-delta distribution in "
+        "Firefox today' is 0.9 — the job is done. 'lego renews ACME certs, so "
+        "renewal is covered, but nothing there models blast radius' is 0.35 — "
+        "adjacent tooling, different job."
+    ),
+    "wrong": (
+        "Calibration: 'the draft assumes 2420-byte ML-DSA signatures; ML-DSA-65 "
+        "is 3309 bytes per FIPS 204 Table 2, so the size budget is off by 37%' "
+        "is 0.75 — cited, recomputed, material. 'The draft says OCSP when it "
+        "means OCSP stapling' is 0.25 — sloppy wording, same mechanism."
+    ),
+}
+
+
+def _prior_art_block(prior_art: list[dict] | None) -> str:
+    """Named, existing repositories for the `solved` lens to adjudicate.
+
+    Empty when the search found nothing or could not run — and it says which,
+    because 'the search found nothing' is evidence of novelty while 'the
+    search could not run' is evidence of nothing at all."""
+    if not prior_art:
+        return (
+            "### Candidate prior art\n"
+            "(none supplied — a GitHub search either found no close match or "
+            "could not run. Do not treat this as proof of novelty.)\n"
+        )
+    lines = []
+    for repo in prior_art[:MAX_PRIOR_ART_SHOWN]:
+        name = str(repo.get("name") or "?")
+        stars = repo.get("stars") or 0
+        desc = str(repo.get("description") or "").strip()[:200]
+        lines.append(f"- {name} ({stars} stars): {desc}")
+    return (
+        "### Candidate prior art (real repositories, found by search)\n"
+        + "\n".join(lines)
+        + "\nThese are the closest existing projects by vocabulary overlap. "
+        "Sharing vocabulary is not doing the same job — say which of these, "
+        "if any, actually does it.\n"
+    )
+
+
+def _idea_block(idea: Idea) -> str:
+    return (
+        f"## {idea.name}\n"
+        f"**Tagline:** {idea.tagline}\n"
+        f"**Description:** {idea.description}\n"
+        f"**Market:** {idea.market_analysis}\n"
+        f"**MVP:** {idea.mvp_scope}\n"
+        f"**Tech:** {', '.join(idea.tech_stack)}\n"
+        f"**Anchor:** {idea.pki_anchor or '(none cited)'}\n"
+    )
+
+
+def lens_prompt(lens: str, idea: Idea, prior_art: list[dict] | None = None) -> str:
+    """The adversarial prompt for one lens. Public so tests (and future
+    probe logging) can inspect exactly what the panel was asked.
+
+    `prior_art` only reaches the `solved` lens — it is the one lens whose
+    question ("does this already exist?") has external evidence available,
+    and the one whose hallucinations are fatal."""
+    evidence = f"{_prior_art_block(prior_art)}\n" if lens == FATAL_LENS else ""
+    schema = (
+        '{"objection": "<one or two sentences, or \'none\'>", "severity": 0.0-1.0'
+        + (', "citation": "<document and section, or empty>"' if lens == "wrong" else "")
+        + "}"
+    )
+    return (
+        "You are a senior PKI engineer on a red team. Your job is to find the "
+        "flaw in the proposal below, not to be fair to it. A proposal you "
+        "cannot fault is rare; say so plainly when that is the case rather "
+        "than manufacturing a nit.\n\n"
+        f"{_LENS_BRIEF[lens]}\n\n"
+        f"{_idea_block(idea)}\n"
+        f"{evidence}"
+        f"Respond with JSON only: {schema}\n"
+        "severity 0.9+ = fatal, the proposal should not exist as written. "
+        "0.7-0.9 = a serious problem the author must answer. Below 0.4 = a "
+        "nit. Use 'none' with severity 0.0 when this lens finds nothing.\n"
+        f"{_SEVERITY_ANCHORS[lens]}"
+    )
+
+
+def revise_prompt(idea: Idea, objections: list[Objection], prior_art: list[dict] | None = None) -> str:
+    """The single rewrite pass. Carries the surviving objections verbatim so
+    the model answers the actual criticism instead of polishing prose, and
+    the named prior art so it differentiates against real projects.
+
+    Only called when the panel actually landed something — a rewrite with no
+    criticism to answer cannot improve the draft and can only dilute it."""
+    panel = "\n".join(f"- [{o.lens}, severity {o.severity:.2f}] {o.text}" for o in objections)
+    return (
+        "You are a senior PKI engineer rewriting your own proposal after a "
+        "red-team review. Below is the draft and every objection the panel "
+        "raised.\n\n"
+        "Rewrite the proposal so that it:\n"
+        "  1. sharpens the mechanism into something an engineer could start "
+        "on Monday — concrete artifacts, concrete failure mode;\n"
+        "  2. drops any claim that did not survive the objections;\n"
+        "  3. states the STRONGEST remaining counterargument explicitly, in "
+        "the description, and answers it or concedes it;\n"
+        "  4. differentiates explicitly against any named prior art below.\n\n"
+        "Keep the citation/anchor in the description text. Do not inflate: if "
+        "the objections shrank the scope, the rewrite should be smaller than "
+        "the draft, not bigger.\n\n"
+        f"### Draft\n{_idea_block(idea)}\n"
+        f"### Panel objections\n{panel}\n\n"
+        f"{_prior_art_block(prior_art)}\n"
+        'Respond with JSON only: {"name": "...", "tagline": "...", '
+        '"description": "...", "mvp_scope": "...", "market_analysis": "...", '
+        '"added_specifics": ["<concrete detail this rewrite adds that the '
+        'draft did not have>"], "dropped_claims": ["<claim the objections '
+        'killed>"]}\n'
+        "added_specifics and dropped_claims are not optional and must not "
+        "both be empty. A rewrite that adds no specific and drops no claim is "
+        "the draft with different adjectives, and it will be discarded."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# parsing                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _unfence(raw: str) -> str:
+    if "```json" in raw:
+        return raw.split("```json", 1)[1].split("```", 1)[0].strip()
+    if "```" in raw:
+        return raw.split("```", 1)[1].split("```", 1)[0].strip()
+    return raw.strip()
+
+
+def _load(raw: str | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        data = json.loads(_unfence(raw))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _parse_objection(lens: str, raw: str | None) -> Objection | None:
+    """One lens's reply → an Objection, or None when it found nothing or
+    replied with something we cannot read. An unreadable lens is a lost
+    opinion, never a reason to kill or to abort the panel."""
+    data = _load(raw)
+    if data is None:
+        logger.info("pki depth: lens %s returned unparseable output", lens)
+        return None
+    text = str(data.get("objection") or "").strip()
+    if not text or text.lower().rstrip(".") in _NULL_OBJECTIONS:
+        return None
+    try:
+        severity = float(data.get("severity", 0.0))
+    except (TypeError, ValueError):
+        severity = 0.0
+    severity = max(0.0, min(1.0, severity))
+    if severity <= 0.0:
+        return None
+
+    if lens == "wrong":
+        citation = str(data.get("citation") or "").strip()
+        if citation:
+            text = f"{text} [{citation}]"
+        elif severity > UNCITED_SEVERITY_CAP:
+            # An uncited factual correction is the shape that reads most
+            # authoritative and is checkable least. Keep it for the rewrite,
+            # deny it a vote.
+            logger.info("pki depth: uncited 'wrong' objection demoted from %.2f", severity)
+            severity = UNCITED_SEVERITY_CAP
+    return Objection(lens=lens, severity=severity, text=text)
+
+
+def _as_text(value: Any) -> str | None:
+    """Coerce a revised field to text. Models routinely return `mvp_scope` as
+    a JSON list of phases; discarding the whole revision over the container
+    type throws away a call for nothing."""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list) and value and all(isinstance(v, str) for v in value):
+        return "\n".join(v.strip() for v in value).strip()
+    return None
+
+
+def _nonempty_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if not isinstance(value, list):
+        return []
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+def _apply_revision(idea: Idea, raw: str | None) -> Idea | None:
+    """Revised Idea, or None when the reply is unusable.
+
+    Identity (`id`, `category`, `content_hash`, every score) is carried over
+    by construction: only `REVISABLE_FIELDS` are copied out of the reply.
+
+    The rewrite must also declare what it added and what it dropped. Nothing
+    downstream can tell "sharpened the mechanism" from "changed three
+    adjectives", so the model has to name the delta; a rewrite that names
+    none is discarded in favour of the draft. Costs a call, but a silently
+    accepted reword is the whole failure mode this stage exists to prevent."""
+    data = _load(raw)
+    if data is None:
+        return None
+    updates: dict[str, str] = {}
+    for key in REVISABLE_FIELDS:
+        value = _as_text(data.get(key))
+        if value is None or not (_MIN_FIELD_LEN <= len(value) <= _MAX_FIELD_LEN):
+            return None
+        updates[key] = value
+
+    if not (_nonempty_list(data.get("added_specifics")) or _nonempty_list(data.get("dropped_claims"))):
+        logger.info("pki depth: revision declared no added specifics and no dropped claims; keeping draft")
+        return None
+
+    return idea.model_copy(update=updates)
+
+
+def _killed(objections: list[Objection]) -> bool:
+    """The panel's veto. See FATAL_LENS / KILL_OBJECTION_COUNT.
+
+    The fatal lens vetoes alone, so it answers to a higher bar than the vote
+    does — the same bar the prompt's own rubric calls "should not exist as
+    written"."""
+    if any(o.lens == FATAL_LENS and o.severity >= FATAL_SEVERITY for o in objections):
+        return True
+    return len([o for o in objections if o.severity >= HIGH_SEVERITY]) >= KILL_OBJECTION_COUNT
+
+
+def _strongest(objections: list[Objection]) -> str | None:
+    """The objection worth showing an operator, or None. Sorted input."""
+    for obj in objections:
+        if obj.severity >= OBJECTION_DISPLAY_FLOOR:
+            return obj.text
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# entry point                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+async def deepen(idea: Idea, *, prior_art: list[dict] | None = None) -> DepthResult:
+    """Run the three-lens panel and the revise pass over an admitted draft.
+
+    `prior_art` is the prior-art search's near-miss list. It grounds the
+    `solved` lens: with it, that lens adjudicates repositories that exist;
+    without it, it is recalling tool names from weights, which is the prompt
+    shape that invents a plausible tool and kills good work with it.
+
+    Returns the revised idea plus the objections it had to survive. With no
+    cheap backend this is a no-op that costs nothing and changes nothing —
+    the board still publishes, just without the depth."""
+    backend = resolve_cheap_backend()
+    if backend is None:
+        return DepthResult(idea=idea, objections=[], strongest=None, survived=True, passes=0)
+
+    passes = 0
+    objections: list[Objection] = []
+    for lens in LENSES:
+        # `backend.call` is a blocking subprocess (up to 180s each). On the
+        # event loop that stalls the dashboard and every other cadence, so it
+        # goes to a thread. Sequential on purpose: the lenses are cheap
+        # relative to the hourly cadence, and a stable call order keeps the
+        # panel comparable across fires.
+        raw = await asyncio.to_thread(backend.call, lens_prompt(lens, idea, prior_art))
+        passes += 1
+        obj = _parse_objection(lens, raw)
+        if obj is not None:
+            objections.append(obj)
+
+    objections.sort(key=lambda o: o.severity, reverse=True)
+    strongest = _strongest(objections)
+
+    if _killed(objections):
+        logger.info("pki depth: panel killed %r (strongest: %s)", idea.name, strongest or objections[0].text)
+        return DepthResult(
+            idea=idea,
+            objections=objections,
+            strongest=strongest or objections[0].text,
+            survived=False,
+            passes=passes,
+        )
+
+    if not objections:
+        # Nothing to answer. A rewrite here has no criticism to work from and
+        # can only dilute a draft the panel could not fault.
+        return DepthResult(idea=idea, objections=[], strongest=None, survived=True, passes=passes)
+
+    raw_revision = await asyncio.to_thread(backend.call, revise_prompt(idea, objections, prior_art))
+    passes += 1
+    revised = _apply_revision(idea, raw_revision)
+
+    return DepthResult(
+        idea=revised if revised is not None else idea,
+        objections=objections,
+        # The objection is published as one the proposal answers. When the
+        # rewrite never landed, the text below it answers nothing, so there
+        # is nothing honest to show.
+        strongest=strongest if revised is not None else None,
+        survived=True,
+        passes=passes,
+        revised=revised is not None,
+    )
+
+
+__all__ = [
+    "FATAL_LENS",
+    "FATAL_SEVERITY",
+    "HIGH_SEVERITY",
+    "KILL_OBJECTION_COUNT",
+    "LENSES",
+    "MAX_PRIOR_ART_SHOWN",
+    "OBJECTION_DISPLAY_FLOOR",
+    "REVISABLE_FIELDS",
+    "UNCITED_SEVERITY_CAP",
+    "DepthResult",
+    "Objection",
+    "deepen",
+    "lens_prompt",
+    "revise_prompt",
+]

--- a/src/project_forge/engine/pki_prior_art.py
+++ b/src/project_forge/engine/pki_prior_art.py
@@ -1,0 +1,370 @@
+"""Prior-art gate for the PKI board — "does this already exist?".
+
+The /pki admission gate already refuses items with no anchor and no
+urgency. It never asked the question that actually kills certificate
+tooling: somebody shipped this in 2017 and it has four thousand stars.
+There are dozens of expiry monitors, ACME clients and chain checkers, and
+an item that duplicates one of them is landfill no matter how urgent the
+underlying problem is.
+
+This module asks GitHub. Keyless, best-effort, capped at a handful of
+requests per check, cached per search term so the hourly cadence does not
+re-query the same thing every fire.
+
+Two deliberate biases:
+
+  - It matches on PURPOSE, not domain. A repo that merely mentions
+    certificates proves nothing — half of GitHub mentions certificates.
+    Overlap on the job being done is what counts, and it is weighted by
+    stars: an abandoned 3-star script does not kill an idea, a 4k-star
+    maintained tool does.
+  - It FAILS OPEN. Any network error, rate limit, or unparseable body
+    returns exists=False with a reason saying the check could not run. A
+    transient blip must never masquerade as "already exists" and silently
+    bin a good finding — the gate above this one is already strict enough
+    that false rejections are the expensive failure mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote_plus
+
+from project_forge.feeds._http import http_get_bytes as _http_get_bytes
+from project_forge.models import Idea
+
+logger = logging.getLogger(__name__)
+
+
+GITHUB_REPO_SEARCH = "https://api.github.com/search/repositories?q={q}&sort=stars&order=desc&per_page=5"
+
+# Request budget. Terms are ranked, so the cheapest useful searches run
+# first; anything beyond this is diminishing returns against a rate limit
+# we share with the gap probe.
+MAX_SEARCH_TERMS = 4
+MAX_SEARCH_REQUESTS = 3
+MAX_QUERY_TOKENS = 4
+MAX_MATCHES = 5
+
+# Words that would match half of GitHub. Stripped from search terms so we
+# query the job, not the product noun.
+# fmt: off
+GENERIC_FILLER: frozenset[str] = frozenset(
+    {
+        "tool", "tooling", "toolkit", "platform", "system", "manager", "management",
+        "service", "framework", "solution", "engine", "app", "application", "suite",
+        "kit", "hub", "portal", "project", "product", "dashboard", "utility", "helper",
+        "library", "server", "client", "api", "cli", "open", "source", "simple", "easy",
+        "modern", "fast", "lightweight", "based", "using", "via", "across", "your",
+        "that", "this", "with", "from", "into", "onto", "over", "under", "and", "the",
+        "for", "are", "all", "any", "new", "one", "its", "it's", "them", "they", "you",
+        "when", "what", "which", "while", "before", "after", "without", "within",
+    }
+)
+# fmt: on
+
+# High-signal certificate vocabulary. These survive filler-stripping even
+# when short, and they are what makes a query specific enough to be worth
+# spending a request on.
+# fmt: off
+DOMAIN_TOKENS: frozenset[str] = frozenset(
+    {
+        "crl", "crlite", "ocsp", "stapling", "acme", "x509", "csr", "hsm", "pkcs11",
+        "spiffe", "spire", "mtls", "tls", "ssl", "pki", "ca", "certificate",
+        "revocation", "expiry", "renewal", "issuance", "rotation", "chain",
+        "trust", "anchor", "root", "intermediate", "transparency", "sct", "ct",
+        "attestation", "quantum", "pqc", "kyber", "dilithium", "dsa", "kem",
+        "hybrid", "keystore", "truststore", "cbom", "signing", "ceremony",
+    }
+)
+# fmt: on
+
+# Domain markers that, on their own, prove only that two things live in the
+# same neighbourhood. Overlap here is nearly worthless for prior art.
+# fmt: off
+_TOPICAL_BASE: frozenset[str] = frozenset(
+    {
+        "certificate", "x509", "pki", "tls", "ssl", "crypto", "cryptography",
+        "security", "secure", "ca", "key", "digital", "identity", "encryption",
+    }
+)
+# fmt: on
+
+# EVERY domain word is topical. This board is entirely about certificates, so
+# `ocsp`, `crl`, `hsm`, `ceremony` and friends are the vocabulary two items
+# share by virtue of both being PKI, not evidence they do the same job. Left
+# out of this set they scored as purpose, and two shared nouns plus a popular
+# repo cleared the kill threshold on their own: "PQ Chain Sizer" died on
+# {chain, handshake} against a TLS fuzzer, "Ceremony Rehearsal Kit" on
+# {ceremony, hsm} against SoftHSM. Neither repo does the job. Domain-vocabulary
+# collision is inevitable here and must never be the dominant kill signal.
+TOPICAL_TOKENS: frozenset[str] = _TOPICAL_BASE | DOMAIN_TOKENS
+
+# Match weights. Purpose overlap is what we are actually buying; topical
+# overlap is a rounding error that only breaks ties.
+PURPOSE_TOKEN_WEIGHT = 0.28
+TOPICAL_TOKEN_WEIGHT = 0.06
+MAX_PURPOSE_TOKENS_COUNTED = 4
+MAX_TOPICAL_TOKENS_COUNTED = 2
+
+# Star weighting. Popularity is the cheapest available proxy for "is this
+# maintained and would an engineer find it before finding us".
+STAR_ABANDONED = 50  # below this: a script, not a tool
+STAR_ESTABLISHED = 400  # above this: people actually depend on it
+STAR_ABANDONED_FACTOR = 0.45
+STAR_MODEST_FACTOR = 0.75
+STAR_ESTABLISHED_FACTOR = 1.0
+
+# Verdict thresholds.
+MATCH_THRESHOLD = 0.55  # at or above: this idea already exists
+MATCH_REPORT_THRESHOLD = 0.30  # worth showing in the probe log either way
+
+# Token normalisation so "certs", "monitoring" and "expiration" collapse
+# onto the same concept as their counterparts in a repo description.
+_ALIASES: dict[str, str] = {
+    "certs": "certificate",
+    "cert": "certificate",
+    "certificates": "certificate",
+    "certificat": "certificate",
+    "monitoring": "monitor",
+    "monitors": "monitor",
+    "expiration": "expiry",
+    "expiring": "expiry",
+    "expires": "expiry",
+    "expire": "expiry",
+    "alerting": "alert",
+    "alerts": "alert",
+    "checker": "check",
+    "checking": "check",
+    "checks": "check",
+    "renewals": "renewal",
+    "renewing": "renewal",
+    "renew": "renewal",
+    "rotating": "rotation",
+    "revoke": "revocation",
+    "revoked": "revocation",
+    "revoking": "revocation",
+    "postquantum": "quantum",
+    "fleets": "fleet",
+}
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Per-term result cache. The cadence fires hourly against a slow-moving
+# corpus; re-asking GitHub the same question every hour is pure waste.
+# Bounded and FIFO-evicted: uvicorn processes live for weeks, and an
+# unbounded dict here would also pin a stale empty result for a term
+# forever.
+MAX_CACHE_ENTRIES = 256
+_SEARCH_CACHE: dict[str, list[dict]] = {}
+
+
+@dataclass
+class PriorArtVerdict:
+    """The gate's answer. `exists=True` means a real, maintained tool already
+    does this job — the idea should not reach the board."""
+
+    exists: bool
+    confidence: float
+    matches: list[dict] = field(default_factory=list)
+    reason: str = ""
+
+
+def clear_prior_art_cache() -> None:
+    """Drop the per-term cache. Used by tests and by anything that wants a
+    genuinely fresh look."""
+    _SEARCH_CACHE.clear()
+
+
+def _normalize(text: str) -> str:
+    return (
+        (text or "")
+        .lower()
+        .replace("x.509", "x509")
+        .replace("pkcs#11", "pkcs11")
+        .replace("post-quantum", "postquantum")
+    )
+
+
+def _tokens(text: str) -> list[str]:
+    """Significant, normalised tokens — filler and stopwords removed."""
+    out: list[str] = []
+    for raw in _TOKEN_RE.findall(_normalize(text)):
+        token = _ALIASES.get(raw, raw)
+        if token in GENERIC_FILLER:
+            continue
+        if token in DOMAIN_TOKENS:
+            out.append(token)
+            continue
+        if len(token) < 3 or token.isdigit():
+            continue
+        out.append(token)
+    return out
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    return list(dict.fromkeys(i for i in items if i))
+
+
+def extract_search_terms(idea: Idea) -> list[str]:
+    """2-4 high-signal GitHub queries derived from the idea's name and
+    tagline. Empty when the idea is pure marketing nouns — nothing worth
+    spending a request on, and nothing a search could meaningfully match."""
+    name = _dedupe(_tokens(idea.name))
+    tag = _tokens(idea.tagline)
+    domain = _dedupe([t for t in name + tag if t in DOMAIN_TOKENS])
+    # Query building uses the NARROW topical set: `crl` is a poor scoring
+    # signal but an excellent search term, and dropping it here would retrieve
+    # the wrong neighbourhood entirely.
+    purpose = _dedupe([t for t in tag if t not in _TOPICAL_BASE])
+
+    # A query built from "certificate tls pki" retrieves the whole
+    # neighbourhood; one built from "spiffe hsm crl" retrieves the actual
+    # competitors. Specific tokens go first, broad ones only pad it out.
+    domain.sort(key=lambda t: t in _TOPICAL_BASE)
+
+    queries: list[str] = []
+    if name:
+        queries.append(" ".join(name[:MAX_QUERY_TOKENS]))
+    if purpose:
+        queries.append(" ".join(_dedupe(domain[:2] + purpose)[:MAX_QUERY_TOKENS]))
+    if len(domain) >= 2:
+        queries.append(" ".join(domain[:MAX_QUERY_TOKENS]))
+    return _dedupe(queries)[:MAX_SEARCH_TERMS]
+
+
+def _star_factor(stars: int) -> float:
+    if stars < STAR_ABANDONED:
+        return STAR_ABANDONED_FACTOR
+    if stars < STAR_ESTABLISHED:
+        return STAR_MODEST_FACTOR
+    return STAR_ESTABLISHED_FACTOR
+
+
+def score_match(idea: Idea, repo: dict) -> float:
+    """How strongly this repo is prior art for this idea, in [0.0, 1.0].
+
+    Purpose overlap carries the score; shared domain vocabulary barely
+    counts, because "also about certificates" describes thousands of
+    repos — and on this board, "also about OCSP" describes most of them.
+    The result is scaled by popularity: an unmaintained match is evidence
+    somebody tried, not evidence the problem is solved."""
+    idea_tokens = set(_tokens(idea.name)) | set(_tokens(idea.tagline))
+    repo_tokens = set(_tokens(str(repo.get("name") or ""))) | set(_tokens(str(repo.get("description") or "")))
+    overlap = idea_tokens & repo_tokens
+    if not overlap:
+        return 0.0
+
+    topical = overlap & TOPICAL_TOKENS
+    purpose = overlap - TOPICAL_TOKENS
+    if not purpose:
+        return 0.0  # same neighbourhood, different job
+
+    raw = min(len(purpose), MAX_PURPOSE_TOKENS_COUNTED) * PURPOSE_TOKEN_WEIGHT
+    raw += min(len(topical), MAX_TOPICAL_TOKENS_COUNTED) * TOPICAL_TOKEN_WEIGHT
+    raw = min(1.0, raw)
+
+    stars = repo.get("stars")
+    return max(0.0, min(1.0, raw * _star_factor(int(stars) if isinstance(stars, int | float) else 0)))
+
+
+def _parse_repos(payload: Any) -> list[dict]:
+    """GitHub repo-search JSON -> our repo shape.
+
+    Raises ValueError when the body is not a repo-search result — a rate
+    limit reply is a well-formed JSON object with a `message` and no
+    `items`, and treating that as "zero results" would be a lie the caller
+    must not act on."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+        raise ValueError(f"not a repo-search result: {str(payload)[:120]}")
+    out: list[dict] = []
+    for item in payload["items"]:
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("full_name") or item.get("name") or "").strip()
+        if not name:
+            continue
+        out.append(
+            {
+                "name": (item.get("name") or name).strip(),
+                "url": item.get("html_url") or "",
+                "stars": int(item.get("stargazers_count") or 0),
+                "description": (item.get("description") or "").strip()[:400],
+            }
+        )
+    return out
+
+
+async def _search(term: str, http_get: Callable[..., bytes]) -> list[dict]:
+    """One cached GitHub repo search. Raises on any failure so the caller
+    can count it as a miss rather than as an empty result."""
+    if term in _SEARCH_CACHE:
+        return _SEARCH_CACHE[term]
+    url = GITHUB_REPO_SEARCH.format(q=quote_plus(term))
+    raw = await asyncio.to_thread(http_get, url, timeout=15.0)
+    repos = _parse_repos(json.loads(raw.decode("utf-8", errors="replace")))
+    while len(_SEARCH_CACHE) >= MAX_CACHE_ENTRIES:
+        _SEARCH_CACHE.pop(next(iter(_SEARCH_CACHE)))
+    _SEARCH_CACHE[term] = repos
+    return repos
+
+
+async def check_prior_art(idea: Idea, *, http_get: Callable[..., bytes] = _http_get_bytes) -> PriorArtVerdict:
+    """Does a maintained tool already do this job?
+
+    Never raises, and never reports `exists=True` on incomplete evidence:
+    if every search failed we say so in the reason and let the idea
+    through."""
+    terms = extract_search_terms(idea)
+    if not terms:
+        return PriorArtVerdict(
+            exists=False,
+            confidence=0.0,
+            matches=[],
+            reason="prior-art check could not run: no searchable terms in name/tagline",
+        )
+
+    repos: dict[str, dict] = {}
+    attempted = 0
+    succeeded = 0
+    for term in terms[:MAX_SEARCH_REQUESTS]:
+        attempted += 1
+        try:
+            found = await _search(term, http_get)
+        except Exception as exc:  # noqa: BLE001 — best-effort, fails open
+            logger.info("prior-art: search %r unavailable (%s)", term, exc)
+            continue
+        succeeded += 1
+        for r in found:
+            repos.setdefault(r["url"] or r["name"], r)
+
+    if succeeded == 0:
+        return PriorArtVerdict(
+            exists=False,
+            confidence=0.0,
+            matches=[],
+            reason=f"prior-art check could not run: all {attempted} GitHub searches failed",
+        )
+
+    scored = sorted(
+        ((score_match(idea, r), r) for r in repos.values()),
+        key=lambda pair: pair[0],
+        reverse=True,
+    )
+    matches = [r for score, r in scored if score >= MATCH_REPORT_THRESHOLD][:MAX_MATCHES]
+    best = scored[0][0] if scored else 0.0
+
+    if best >= MATCH_THRESHOLD:
+        top = scored[0][1]
+        reason = f"prior art: {top['name']} ({top['stars']} stars) already does this — {top['url']}"
+        return PriorArtVerdict(exists=True, confidence=best, matches=matches, reason=reason)
+
+    near = f"; closest was {scored[0][1]['name']} at {best:.2f}" if matches else ""
+    reason = f"no prior art found across {succeeded}/{attempted} searches, {len(repos)} repos examined{near}"
+    return PriorArtVerdict(exists=False, confidence=best, matches=matches, reason=reason)

--- a/src/project_forge/models.py
+++ b/src/project_forge/models.py
@@ -172,6 +172,21 @@ PKI_CATEGORIES: tuple["IdeaCategory", ...] = (
 )
 
 
+# Categories whose board owns its own ADMISSION GATE. The general generation
+# rotation (expand, template auto-scan, super-idea horizontal) must not
+# produce into these: anything that arrives outside the gated cadence would
+# otherwise land in the category, get back-filled a score, and appear on a
+# board that advertises itself as selective.
+#
+# This is the "back door" fix. The PKI board shipped with a hard gate on its
+# own cadence while the ordinary rotation kept generating into the same five
+# categories — 28 of the first 77 board items had never seen the gate, and
+# 201 more were queued behind the score back-fill. The board query ALSO
+# filters on generation_mode, so this constant is the efficiency half (stop
+# generating what the board will never show) and the query is the guarantee.
+GATED_CATEGORIES: tuple["IdeaCategory", ...] = PKI_CATEGORIES
+
+
 IdeaStatus = Literal["new", "approved", "scaffolded", "rejected", "archived", "contributed", "implemented"]
 
 
@@ -243,6 +258,11 @@ class Idea(BaseModel):
     # CA/B Forum ballot, a tracker issue, a compliance deadline. Required
     # for admission to /pki: no anchor means it's a vibe, not a finding.
     pki_anchor: str | None = None
+    # The strongest counterargument the red-team panel raised that the
+    # revision could not make go away. Surfaced on the card on purpose: a
+    # finding that admits what is wrong with it is worth more to an engineer
+    # than one that pretends the objection was never made.
+    pki_objection: str | None = None
 
 
 MissionStatus = Literal["active", "paused", "archived"]

--- a/src/project_forge/storage/db.py
+++ b/src/project_forge/storage/db.py
@@ -333,6 +333,9 @@ class Database:
             # anchored to. Both NULL outside the PKI categories.
             "ALTER TABLE ideas ADD COLUMN pki_urgency_score REAL",
             "ALTER TABLE ideas ADD COLUMN pki_anchor TEXT",
+            # The surviving red-team objection from the depth panel. NULL
+            # when the panel found nothing, or ran keyless.
+            "ALTER TABLE ideas ADD COLUMN pki_objection TEXT",
         ):
             try:
                 await self._db.execute(stmt)
@@ -403,8 +406,8 @@ class Database:
                  github_issue_url, project_repo_url, content_hash, source_url,
                  generation_mode, fundability_score, auto_promoted_at, ambition_score,
                 artifact_type, snipe_score, target_incumbent, mission_id, cashflow_score,
-                pki_urgency_score, pki_anchor)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                pki_urgency_score, pki_anchor, pki_objection)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     idea.id,
                     idea.name,
@@ -432,6 +435,7 @@ class Database:
                     getattr(idea, "cashflow_score", None),
                     getattr(idea, "pki_urgency_score", None),
                     getattr(idea, "pki_anchor", None),
+                    getattr(idea, "pki_objection", None),
                 ),
             )
             await self.db.commit()
@@ -1500,6 +1504,7 @@ class Database:
             cashflow_score=(row["cashflow_score"] if "cashflow_score" in keys else None),
             pki_urgency_score=(row["pki_urgency_score"] if "pki_urgency_score" in keys else None),
             pki_anchor=(row["pki_anchor"] if "pki_anchor" in keys else None),
+            pki_objection=(row["pki_objection"] if "pki_objection" in keys else None),
         )
 
     # === RESOURCE CRUD ===

--- a/src/project_forge/web/lifespan_scheduler.py
+++ b/src/project_forge/web/lifespan_scheduler.py
@@ -528,6 +528,25 @@ async def _fire_pki_score(db: Database) -> None:
     logger.info("PKI scoring cycle scored %d ideas", result.get("scored", 0))
 
 
+async def _record_pki_drop(
+    db: Database,
+    gap: dict,
+    *,
+    anchor: str | None,
+    reason: str,
+    score: float | None = None,
+) -> None:
+    """Log a probe that stored nothing. Every rejection stage funnels through
+    here so a quiet hour always says which stage did the dropping."""
+    await db.record_pki_probe(
+        gap_summary=gap.get("title"),
+        anchor=anchor,
+        admitted=False,
+        reason=reason,
+        urgency_score=score,
+    )
+
+
 async def _fire_pki(db: Database) -> None:
     """The hourly PKI probe: ONE target, and it is allowed to come back empty.
 
@@ -536,24 +555,37 @@ async def _fire_pki(db: Database) -> None:
     probe, picks the single highest-leverage gap it found, works that one
     gap hard, and then applies an admission gate that most attempts fail.
 
-      probe -> pick ONE gap -> generate one spec-grade item -> gate -> store or DROP
+      probe -> pick ONE gap -> generate draft -> red-team panel -> gate ->
+      prior-art check -> store or DROP
 
-    There is no fallback generation. If the probe finds nothing, or the
-    generator produces something unanchored, or the urgency score lands
-    below the threshold, this cadence stores NOTHING and logs why. That is
-    the intended behavior: the board is a short list of things that matter,
-    not an hourly deposit. Every attempt is recorded in `pki_probes` so the
-    quiet hours are auditable and so the schedule has a watermark that
-    advances even when nothing is stored.
+    Selectivity alone was not enough. A gate that admits one draft in ten
+    still admits a single LLM pass: a paragraph that cites an RFC and that a
+    CA engineer would not act on, because nobody tried to break it. So two
+    stages sit either side of the gate. `deepen()` breaks the draft three
+    ways and rewrites it around what survived, and can kill it outright.
+    `check_prior_art()` then asks the question that actually kills
+    certificate tooling — somebody shipped this in 2017 and it has four
+    thousand stars.
+
+    There is no fallback generation. If the probe finds nothing, the panel
+    kills the draft, the score lands below the threshold, or a maintained
+    tool already does the job, this cadence stores NOTHING and logs why.
+    That is the intended behavior: the board is a short list of things that
+    matter, not an hourly deposit. Every attempt is recorded in `pki_probes`
+    so the quiet hours are auditable and so the schedule has a watermark
+    that advances even when nothing is stored.
 
     Touches no GitHub state — governance rule for autonomous cadences.
     """
     from project_forge.engine.dedup import filter_and_save
     from project_forge.engine.llm_generator import generate_idea_llm
     from project_forge.engine.pki import admits, extract_anchor, score_pki_urgency
+    from project_forge.engine.pki_depth import deepen
+    from project_forge.engine.pki_prior_art import check_prior_art
     from project_forge.feeds.pki_probe import fetch_pki_gaps, gap_to_seed, pick_top_gap
     from project_forge.models import IdeaCategory
 
+    gap: dict | None = None
     try:
         # 1. Probe the real sources. Never raises; [] is a normal outcome.
         recent = await db.list_pki_probes(limit=200)
@@ -597,28 +629,64 @@ async def _fire_pki(db: Database) -> None:
         idea.generation_mode = "pki"
         idea.pki_anchor = extract_anchor(idea) or (gap.get("url") or None)
 
-        # 4. The gate. Anchor + urgency threshold + right board.
+        # 4. Has somebody already shipped this? Three cheap HTTP searches,
+        #    and they run FIRST: a duplicate should never cost five LLM
+        #    calls, and the near-misses are the evidence the red team's
+        #    novelty lens needs to adjudicate instead of guess. Fails open by
+        #    design — a rate limit must never masquerade as "already exists".
+        prior = await check_prior_art(idea)
+        if prior.exists:
+            await _record_pki_drop(db, gap, anchor=idea.pki_anchor, reason=prior.reason)
+            logger.info("PKI probe: prior art killed %r — %s", idea.name, prior.reason)
+            return
+
+        # 5. The red team. Three adversarial lenses plus one rewrite around
+        #    what survived. A fatal "already solved" hit, or two landed hits
+        #    anywhere, kills the draft — rewording cannot save an idea that
+        #    is wrong in two dimensions. Keyless this is a free no-op.
+        depth = await deepen(idea, prior_art=prior.matches)
+        if not depth.survived:
+            await _record_pki_drop(
+                db,
+                gap,
+                anchor=idea.pki_anchor,
+                reason=f"red-team panel killed it: {depth.strongest or 'no surviving rationale'}",
+            )
+            logger.info("PKI probe: panel killed %r after %d passes", idea.name, depth.passes)
+            return
+
+        # Score the REVISED text, not the draft the panel tore up. The
+        # objection is only published when the rewrite actually landed —
+        # otherwise the card would show a counterargument the text below it
+        # never answers.
+        idea = depth.idea
+        idea.pki_objection = depth.strongest
+
+        # 6. The gate. Anchor + urgency threshold + right board.
         score = await score_pki_urgency(idea)
         idea.pki_urgency_score = score
         ok, reason = admits(idea, score)
         if not ok:
-            await db.record_pki_probe(
-                gap_summary=gap.get("title"),
+            await _record_pki_drop(
+                db,
+                gap,
                 anchor=idea.pki_anchor or gap.get("url"),
-                admitted=False,
                 reason=reason,
-                urgency_score=score,
+                score=score,
             )
             logger.info("PKI probe: rejected %r — %s", idea.name, reason)
             return
 
-        # 5. Survived the gate; dedup still gets the last word.
+        # 7. Survived everything; dedup still gets the last word. The closest
+        #    prior art rides along on the admitted probe: it is the only
+        #    calibration data available for tuning the match threshold, and
+        #    it was being thrown away every hour.
         _saved, stored, dedup_reason = await filter_and_save(idea, db)
         await db.record_pki_probe(
             gap_summary=gap.get("title"),
             anchor=idea.pki_anchor,
             admitted=bool(stored),
-            reason="admitted" if stored else f"dedup rejected: {dedup_reason}",
+            reason=f"admitted ({prior.reason})" if stored else f"dedup rejected: {dedup_reason}",
             idea_id=idea.id if stored else None,
             urgency_score=score,
         )
@@ -629,8 +697,23 @@ async def _fire_pki(db: Database) -> None:
             score,
             idea.pki_anchor,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception("PKI probe cycle failed")
+        # The watermark is MAX(pki_probes.probed_at), so a crash that records
+        # nothing leaves the cadence permanently overdue: it re-fires every
+        # tick, and because `seen_urls` also comes from the probe log it picks
+        # the SAME gap each time. A deterministic failure would become an
+        # unbounded LLM burn loop on one gap. Recording the crash advances the
+        # watermark and retires the gap.
+        try:
+            await db.record_pki_probe(
+                gap_summary=(gap or {}).get("title"),
+                anchor=(gap or {}).get("url"),
+                admitted=False,
+                reason=f"probe crashed: {type(exc).__name__}: {exc}"[:400],
+            )
+        except Exception:
+            logger.exception("PKI probe: could not record the crash either")
 
 
 async def _fire_auto_promote(db: Database) -> None:

--- a/src/project_forge/web/routes.py
+++ b/src/project_forge/web/routes.py
@@ -1080,6 +1080,7 @@ async def pki(
         f"WHERE category IN ({placeholders}) "
         f"AND status NOT IN ('archived', 'rejected') "
         f"AND pki_urgency_score IS NOT NULL "
+        f"AND generation_mode = 'pki' "
         f"ORDER BY pki_urgency_score DESC, generated_at DESC LIMIT ?",
         (*cats, limit),
     )
@@ -1124,6 +1125,7 @@ async def api_pki_top(limit: int = Query(default=10, ge=1, le=100)):
         f"FROM ideas WHERE category IN ({placeholders}) "
         f"AND status NOT IN ('archived', 'rejected') "
         f"AND pki_urgency_score IS NOT NULL "
+        f"AND generation_mode = 'pki' "
         f"ORDER BY pki_urgency_score DESC, generated_at DESC LIMIT ?",
         (*_PKI_CATEGORIES, limit),
     )

--- a/src/project_forge/web/static/style.css
+++ b/src/project_forge/web/static/style.css
@@ -162,6 +162,24 @@ a:hover { color: var(--accent); }
 .pki-anchor a { color: #3fb8af; text-decoration: none; }
 .pki-anchor a:hover { text-decoration: underline; }
 
+/* The surviving red-team objection. Deliberately styled as a caveat, not as
+   a feature: amber left rule, dimmer than the tagline it sits under. */
+.pki-objection {
+    margin-top: 0.5rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid #c9902f;
+    font-size: 0.72rem;
+    line-height: 1.45;
+}
+.pki-objection-label {
+    display: block;
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #c9902f;
+}
+.pki-objection-text { color: var(--text-dim, #8b93a7); }
+
 .probe-log {
     margin-top: 2.5rem;
     padding-top: 1.5rem;
@@ -201,12 +219,28 @@ a:hover { color: var(--accent); }
     color: #3fb8af;
     word-break: break-all;
 }
-.probe-reason { color: var(--text-dim, #8b93a7); font-style: italic; }
+/* Panel and prior-art rejections are a whole sentence (and sometimes a repo
+   URL), so this claims its own row rather than fighting the gap text. */
+.probe-reason {
+    flex: 1 1 100%;
+    color: var(--text-dim, #8b93a7);
+    font-style: italic;
+    overflow-wrap: anywhere;
+}
 .probe-score {
     font-family: var(--mono, ui-monospace, monospace);
     color: var(--text-dim, #8b93a7);
 }
 .probe-empty { font-size: 0.8rem; color: var(--text-dim, #8b93a7); }
+
+/* Churn on /pki is the raw path — flag it so the vetted-pipeline copy above
+   the button isn't read as a promise this button keeps. */
+.churn-note {
+    margin: 0.5rem 0 0;
+    font-size: 0.72rem;
+    color: var(--text-dim, #8b93a7);
+    font-style: italic;
+}
 
 /* Sniper board accents — the "vs. incumbent" line, the snipe angle pill,
    and the Snipe-Now button tint. */

--- a/src/project_forge/web/templates/pki.html
+++ b/src/project_forge/web/templates/pki.html
@@ -10,8 +10,10 @@
             {{ total }} certificate-infrastructure findings across {{ categories|length }} categories &mdash;
             revocation, lifecycle, post-quantum migration, CA operations, and machine identity &mdash;
             ranked by <strong>urgency</strong>: deadline pressure &times; blast radius &times; how badly
-            today's tooling fails. An hourly probe works <em>one</em> grounded gap and admits it only if
-            it cites a real artifact and clears the bar. Most hours admit nothing &mdash; that is the point.
+            today's tooling fails. An hourly probe works <em>one</em> grounded gap, drops it if existing
+            tooling already does the job, red-teams the survivor three ways, rewrites it to answer the
+            objections, and admits it only if it cites a real artifact and clears the bar. Most hours admit
+            nothing &mdash; that is the point.
         </p>
         <div class="churn-row">
             <button id="churn-btn" class="btn btn-primary btn-churn" type="button">
@@ -20,6 +22,13 @@
             </button>
             <div id="churn-status" class="churn-status"></div>
         </div>
+        {# Churn is the RAW path on purpose: a human clicking it wants to see what
+           the generator produces now, not wait minutes for the panel. Say so, or
+           the pipeline description above reads as a promise this button doesn't keep. #}
+        <p class="churn-note">
+            Churn Now is the raw generator &mdash; no prior-art check, no red-team, no gate.
+            Only the hourly probe produces vetted findings.
+        </p>
     </div>
 </section>
 
@@ -75,6 +84,16 @@
                             {% endif %}
                         </div>
                         {% endif %}
+                        {# The objection the red-team panel raised that the rewrite
+                           could not answer away. Showing it is the whole point: a
+                           finding that names its own weakest joint is actionable,
+                           one that hides it is a pitch. #}
+                        {% if idea.pki_objection %}
+                        <div class="pki-objection" title="Strongest surviving counterargument from the red-team panel">
+                            <span class="pki-objection-label">strongest counterargument</span>
+                            <span class="pki-objection-text">{{ idea.pki_objection }}</span>
+                        </div>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="moneybot-card-foot">
@@ -124,6 +143,9 @@
                     {% if p.anchor %}
                     <span class="probe-anchor">{{ p.anchor }}</span>
                     {% endif %}
+                    {# Reasons now come from four different stages — gate, red-team
+                       panel, prior art, dedup — and the panel/prior-art ones carry a
+                       sentence or a repo URL, so this line has to wrap, not clip. #}
                     <span class="probe-reason">{{ p.reason }}</span>
                     {% if p.urgency_score is not none %}
                     <span class="probe-score">{{ "%.2f"|format(p.urgency_score) }}</span>

--- a/tests/test_db_integrity.py
+++ b/tests/test_db_integrity.py
@@ -142,6 +142,8 @@ EXPECTED_COLUMNS = {
             # so locking them here catches a dropped migration.
             "pki_urgency_score",
             "pki_anchor",
+            # The red-team panel's surviving objection, surfaced on the card.
+            "pki_objection",
         }
     ),
     "filtered_ideas": frozenset(

--- a/tests/test_pki_board.py
+++ b/tests/test_pki_board.py
@@ -30,6 +30,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -104,6 +105,10 @@ def _urgent_idea(**over) -> Idea:
         feasibility_score=0.8,
         mvp_scope="Phase 1: growth model. Phase 2: shard plan emitter.",
         tech_stack=["go", "cfssl", "postgres"],
+        # The canonical board item comes from the gated cadence. Tests that
+        # care about ungated content override this explicitly — see
+        # TestBackDoorClosed.
+        generation_mode="pki",
     )
     base.update(over)
     return Idea(**base)
@@ -112,6 +117,76 @@ def _urgent_idea(**over) -> Idea:
 # --------------------------------------------------------------------------- #
 # grouping                                                                    #
 # --------------------------------------------------------------------------- #
+
+
+class TestBackDoorClosed:
+    """The board advertises a hard admission gate. Anything that reaches it
+    without passing that gate makes the claim false.
+
+    Regression lock for the back door found on 2026-08-08: the five PKI
+    categories sat in the ordinary generation rotation, and the score
+    back-fill scored whatever it found there — so 28 of the first 77 board
+    items had never seen the gate (19 of them from the deterministic
+    template generator), with 201 more queued behind the back-fill.
+    """
+
+    def test_pki_categories_are_gated(self):
+        from project_forge.models import GATED_CATEGORIES
+
+        assert set(GATED_CATEGORIES) == set(PKI_CATEGORIES)
+
+    def test_general_rotation_excludes_gated_categories(self):
+        """The main generate→score→store rotation must not pick a PKI category."""
+        from project_forge.cron.scheduler import ALL_CATEGORIES
+
+        assert not (set(ALL_CATEGORIES) & set(PKI_CATEGORIES))
+
+    def test_template_generator_excludes_gated_categories(self):
+        """auto_scan is the single largest producer in the engine — it was
+        responsible for most of the ungated board items."""
+        import random as _random
+
+        from project_forge.cron.auto_scan import generate_local_idea
+
+        _random.seed(1234)
+        for _ in range(60):
+            idea, *_ = generate_local_idea()
+            assert idea.category not in PKI_CATEGORIES, f"template generator produced a gated category: {idea.category}"
+
+    def test_super_idea_pair_fallback_excludes_gated(self):
+        import random as _random
+
+        from project_forge.cron.horizontal import IdeaCategory as _IC  # noqa: F401
+        from project_forge.models import GATED_CATEGORIES
+
+        cats = [c for c in IdeaCategory if c != IdeaCategory.SELF_IMPROVEMENT and c not in GATED_CATEGORIES]
+        _random.seed(7)
+        a, b = _random.sample(cats, 2)
+        assert a not in GATED_CATEGORIES
+        assert b not in GATED_CATEGORIES
+
+    @pytest.mark.asyncio
+    async def test_backfill_ignores_ungated_pki_ideas(self, db, monkeypatch):
+        """The back-fill was the mechanism that put ungated ideas on the
+        board: a score is what makes an idea visible there."""
+        from project_forge.engine import pki
+
+        monkeypatch.setattr(pki, "resolve_cheap_backend", lambda: None)
+
+        gated = _urgent_idea(name="Gated Finding", content_hash="bd1")
+        gated.generation_mode = "pki"
+        ungated = _urgent_idea(name="Wandered In", content_hash="bd2")
+        ungated.generation_mode = None  # template generator
+        drifted = _urgent_idea(name="Expand Rotation", content_hash="bd3")
+        drifted.generation_mode = "novel"
+        for i in (gated, ungated, drifted):
+            await db.save_idea(i)
+
+        report = await pki.score_pending_pki_urgency(db, limit=10)
+        assert report["scored"] == 1, "back-fill must only score gated items"
+        assert (await db.get_idea(gated.id)).pki_urgency_score is not None
+        assert (await db.get_idea(ungated.id)).pki_urgency_score is None
+        assert (await db.get_idea(drifted.id)).pki_urgency_score is None
 
 
 class TestPkiGrouping:
@@ -659,6 +734,9 @@ class TestCadence:
 
         monkeypatch.setattr("project_forge.engine.llm_generator.generate_idea_llm", _fake_generate)
         monkeypatch.setattr("project_forge.engine.pki.resolve_cheap_backend", lambda: None)
+        # The depth panel runs before the gate now; keep this test keyless so
+        # it still asserts the ANCHOR rejection and never shells out.
+        monkeypatch.setattr("project_forge.engine.pki_depth.resolve_cheap_backend", lambda: None)
 
         await lifespan_scheduler._fire_pki(db)
 
@@ -667,6 +745,318 @@ class TestCadence:
         assert probes[0]["admitted"] is False
         assert "anchor" in (probes[0]["reason"] or "").lower()
         assert (await db.count_ideas()) == 0, "unanchored idea must not reach the board"
+
+
+# --------------------------------------------------------------------------- #
+# depth panel + prior art, wired into the cadence                             #
+# --------------------------------------------------------------------------- #
+
+
+_LENS_MARKERS = {
+    "real": "ATTACK THE PREMISE",
+    "solved": "ATTACK THE NOVELTY",
+    "wrong": "ATTACK THE CORRECTNESS",
+}
+
+
+class _ScriptedBackend:
+    """A cheap backend that answers by prompt shape, so one fake can drive the
+    three lenses and the revise pass without any network."""
+
+    def __init__(self, lens_replies: dict[str, str], revision: str | None = None):
+        self.lens_replies = lens_replies
+        self.revision = revision
+        self.prompts: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return "scripted"
+
+    def call(self, prompt: str) -> str | None:
+        self.prompts.append(prompt)
+        if "rewriting your own proposal" in prompt:
+            return self.revision
+        for lens, brief in _LENS_MARKERS.items():
+            if brief in prompt:
+                return self.lens_replies.get(lens, '{"objection": "none", "severity": 0.0}')
+        raise AssertionError(f"unexpected prompt: {prompt[:80]}")
+
+
+# The revise pass rewrites the text the urgency score is then computed on, so
+# a revision that survives the panel must still carry the urgency signals.
+_REVISION_JSON = (
+    '{"name": "Delta-CRL Shard Planner", '
+    '"tagline": "partition issuing distribution points before CRLs exceed the fetch budget", '
+    '"description": "ML-DSA signatures push CRL size past what clients will fetch. Operators do '
+    "this by hand today with no way to tell which issuing distribution point blows the budget "
+    "next, and a fleet-wide outage follows when revocation stops working at the 2030 deadline. "
+    'Anchored to RFC 5280.", '
+    '"mvp_scope": "Phase 1: growth model against a real CRL corpus.", '
+    '"market_analysis": "Every certificate authority hits this; a fleet-wide outage is the '
+    'failure mode.", '
+    '"added_specifics": ["per-issuing-distribution-point growth model"], '
+    '"dropped_claims": ["that no CA shards CRLs today"]}'
+)
+
+
+def _pki_gap() -> dict:
+    return {
+        "title": "CRL size under ML-DSA",
+        "url": "https://datatracker.ietf.org/doc/draft-ietf-lamps-crl-partitioning/",
+        "summary": "revocation",
+        "gap_score": 9,
+        "category": "pki-revocation",
+    }
+
+
+def _wire_cadence(monkeypatch, idea: Idea) -> None:
+    """Point the cadence at one gap and one generated draft, and keep the
+    urgency scorer keyless so its assertions stay deterministic."""
+    from project_forge.engine.llm_generator import LLMGenerationResult
+
+    monkeypatch.setattr("project_forge.feeds.pki_probe.fetch_pki_gaps", lambda *a, **kw: [_pki_gap()])
+
+    async def _fake_generate(db_, category, **kw):
+        return LLMGenerationResult(idea=idea, mode="novel", persona="p", backend="stub", raw_response="{}")
+
+    monkeypatch.setattr("project_forge.engine.llm_generator.generate_idea_llm", _fake_generate)
+    monkeypatch.setattr("project_forge.engine.pki.resolve_cheap_backend", lambda: None)
+
+
+def _stub_prior_art(monkeypatch, repos: list[dict] | None) -> None:
+    """Feed the REAL prior-art scorer a fixed repo set (or make every search
+    fail, which is the fail-open path). Never touches the network."""
+    from project_forge.engine import pki_prior_art
+
+    pki_prior_art.clear_prior_art_cache()
+
+    async def _fake_search(term, http_get):
+        if repos is None:
+            raise RuntimeError("github unreachable")
+        return repos
+
+    monkeypatch.setattr(pki_prior_art, "_search", _fake_search)
+
+
+class TestCadenceDepthAndPriorArt:
+    """The two stages that turned selectivity into effort. Both must be able
+    to store NOTHING, and both must say so in the probe log."""
+
+    @pytest.mark.asyncio
+    async def test_panel_kill_stores_nothing_and_logs_the_objection(self, db, monkeypatch):
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        draft = _urgent_idea(name="Already Built CRL Thing", content_hash="panel-kill-1")
+        _wire_cadence(monkeypatch, draft)
+        _stub_prior_art(monkeypatch, [])
+
+        killer = "crlite already ships delta distribution in Firefox; this is the same mechanism."
+        monkeypatch.setattr(
+            pki_depth,
+            "resolve_cheap_backend",
+            lambda: _ScriptedBackend({"solved": json.dumps({"objection": killer, "severity": 0.95})}),
+        )
+
+        await lifespan_scheduler._fire_pki(db)
+
+        assert (await db.count_ideas()) == 0, "a killed draft must never reach the board"
+        probes = await db.list_pki_probes(limit=10)
+        assert len(probes) == 1
+        assert probes[0]["admitted"] is False
+        assert "red-team panel" in probes[0]["reason"]
+        assert "crlite" in probes[0]["reason"], "the killing objection itself must be in the log"
+
+    @pytest.mark.asyncio
+    async def test_panel_kill_costs_no_revise_pass(self, db, monkeypatch):
+        """A killed draft is never rewritten — three calls, not four."""
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        _wire_cadence(monkeypatch, _urgent_idea(name="Doomed", content_hash="panel-kill-2"))
+        _stub_prior_art(monkeypatch, [])
+        backend = _ScriptedBackend({"solved": '{"objection": "step-ca does this", "severity": 0.9}'})
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: backend)
+
+        await lifespan_scheduler._fire_pki(db)
+
+        assert len(backend.prompts) == 3
+        assert not any("rewriting your own proposal" in p for p in backend.prompts)
+
+    @pytest.mark.asyncio
+    async def test_prior_art_hit_stores_nothing_and_logs_the_match(self, db, monkeypatch):
+        """The question that actually kills certificate tooling: somebody
+        shipped this in 2017 and it has four thousand stars."""
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        duplicate = _urgent_idea(
+            name="Certificate Expiry Monitor",
+            tagline="monitor certificate expiry across the fleet",
+            content_hash="prior-art-1",
+        )
+        _wire_cadence(monkeypatch, duplicate)
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: None)
+        _stub_prior_art(
+            monkeypatch,
+            [
+                {
+                    "name": "cert-expiry-monitor",
+                    "url": "https://github.com/example/cert-expiry-monitor",
+                    "stars": 4000,
+                    "description": "Monitors certificate expiry across your fleet and alerts before renewal",
+                }
+            ],
+        )
+
+        await lifespan_scheduler._fire_pki(db)
+
+        assert (await db.count_ideas()) == 0, "a solved problem must not reach the board"
+        probes = await db.list_pki_probes(limit=10)
+        assert len(probes) == 1
+        assert probes[0]["admitted"] is False
+        assert "prior art" in probes[0]["reason"]
+        assert "https://github.com/example/cert-expiry-monitor" in probes[0]["reason"]
+
+    @pytest.mark.asyncio
+    async def test_survivor_persists_objection_through_round_trip(self, db, monkeypatch):
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        draft = _urgent_idea(name="Delta-CRL Draft", content_hash="survivor-1")
+        _wire_cadence(monkeypatch, draft)
+        _stub_prior_art(monkeypatch, [])
+
+        objection = "partitioning helps only clients that honour the IDP extension."
+        monkeypatch.setattr(
+            pki_depth,
+            "resolve_cheap_backend",
+            lambda: _ScriptedBackend(
+                {"real": json.dumps({"objection": objection, "severity": 0.55})},
+                revision=_REVISION_JSON,
+            ),
+        )
+
+        await lifespan_scheduler._fire_pki(db)
+
+        probes = await db.list_pki_probes(limit=10)
+        assert probes[0]["admitted"] is True, probes[0]["reason"]
+        stored = await db.get_idea(probes[0]["idea_id"])
+        assert stored is not None
+        assert stored.pki_objection == objection
+        # The board stores the REVISED text, not the draft the panel tore up.
+        assert stored.name == "Delta-CRL Shard Planner"
+
+    @pytest.mark.asyncio
+    async def test_prior_art_runs_before_the_panel_and_grounds_it(self, db, monkeypatch):
+        """Ordering matters twice over: a duplicate must not cost five LLM
+        calls, and the lens holding the only unilateral veto must adjudicate
+        repositories that exist rather than recall tool names from weights."""
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        _wire_cadence(monkeypatch, _urgent_idea(name="Delta-CRL Draft", content_hash="grounded-1"))
+        _stub_prior_art(
+            monkeypatch,
+            [{"name": "crlite", "url": "https://github.com/x/crlite", "stars": 900, "description": "CRL filters"}],
+        )
+        backend = _ScriptedBackend({}, revision=_REVISION_JSON)
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: backend)
+
+        await lifespan_scheduler._fire_pki(db)
+
+        solved = [p for p in backend.prompts if _LENS_MARKERS["solved"] in p]
+        assert len(solved) == 1
+        assert "crlite" in solved[0], "the novelty lens must see the real repos the search found"
+
+    @pytest.mark.asyncio
+    async def test_prior_art_kill_spends_no_llm_calls(self, db, monkeypatch):
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        duplicate = _urgent_idea(
+            name="Certificate Expiry Monitor",
+            tagline="monitor certificate expiry across the fleet",
+            content_hash="prior-art-cheap-1",
+        )
+        _wire_cadence(monkeypatch, duplicate)
+        backend = _ScriptedBackend({}, revision=_REVISION_JSON)
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: backend)
+        _stub_prior_art(
+            monkeypatch,
+            [
+                {
+                    "name": "cert-expiry-monitor",
+                    "url": "https://github.com/example/cert-expiry-monitor",
+                    "stars": 4000,
+                    "description": "Monitors certificate expiry across your fleet and alerts before renewal",
+                }
+            ],
+        )
+
+        await lifespan_scheduler._fire_pki(db)
+
+        assert backend.prompts == [], "a duplicate must be killed by 3 HTTP calls, not 4 LLM calls"
+        assert (await db.count_ideas()) == 0
+
+    @pytest.mark.asyncio
+    async def test_a_crashing_cycle_still_records_a_probe(self, db, monkeypatch):
+        """The watermark is MAX(probed_at) and `seen_urls` comes from the same
+        log, so a crash that records nothing re-fires every tick against the
+        SAME gap — an unbounded burn loop on one deterministic failure."""
+        from project_forge.web import lifespan_scheduler
+
+        _wire_cadence(monkeypatch, _urgent_idea(name="Doomed", content_hash="crash-1"))
+
+        async def _boom(*a, **kw):
+            raise RuntimeError("github schema changed")
+
+        monkeypatch.setattr("project_forge.engine.pki_prior_art.check_prior_art", _boom)
+
+        await lifespan_scheduler._fire_pki(db)
+
+        probes = await db.list_pki_probes(limit=10)
+        assert len(probes) == 1, "a crash must still advance the watermark"
+        assert probes[0]["admitted"] is False
+        assert "crashed" in (probes[0]["reason"] or "")
+        assert probes[0]["anchor"] == _pki_gap()["url"], "the gap must be retired, not retried forever"
+
+    @pytest.mark.asyncio
+    async def test_admitted_probe_records_the_closest_prior_art(self, db, monkeypatch):
+        """Free calibration data for tuning the match threshold, and it was
+        being deleted every hour."""
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        _wire_cadence(monkeypatch, _urgent_idea(name="Delta-CRL Planner", content_hash="calib-1"))
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: None)
+        _stub_prior_art(monkeypatch, [])
+
+        await lifespan_scheduler._fire_pki(db)
+
+        probes = await db.list_pki_probes(limit=10)
+        assert probes[0]["admitted"] is True, probes[0]["reason"]
+        assert "searches" in probes[0]["reason"], "the prior-art evidence must ride along"
+
+    @pytest.mark.asyncio
+    async def test_fully_keyless_path_still_admits(self, db, monkeypatch):
+        """No LLM, no network: the panel is a free no-op and the prior-art
+        check fails open. The board must still publish."""
+        from project_forge.engine import pki_depth
+        from project_forge.web import lifespan_scheduler
+
+        _wire_cadence(monkeypatch, _urgent_idea(name="Keyless Survivor", content_hash="keyless-1"))
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: None)
+        _stub_prior_art(monkeypatch, None)  # every search fails
+
+        await lifespan_scheduler._fire_pki(db)
+
+        probes = await db.list_pki_probes(limit=10)
+        assert probes[0]["admitted"] is True, probes[0]["reason"]
+        stored = await db.get_idea(probes[0]["idea_id"])
+        assert stored is not None
+        assert stored.name == "Keyless Survivor"
+        assert stored.pki_objection is None, "keyless runs no panel, so there is no objection"
 
 
 # --------------------------------------------------------------------------- #
@@ -683,6 +1073,7 @@ async def client(tmp_path):
     a = _urgent_idea(name="PKI High", content_hash="ra")
     a.pki_urgency_score = 0.91
     a.pki_anchor = "RFC 5280"
+    a.pki_objection = "only helps clients that honour the IDP extension"
     a.generation_mode = "pki"
     b = _urgent_idea(name="PKI Low", category=IdeaCategory.CA_OPERATIONS, content_hash="rb")
     b.pki_urgency_score = 0.58
@@ -702,6 +1093,25 @@ async def client(tmp_path):
 
 
 class TestPkiRoutes:
+    @pytest.mark.asyncio
+    async def test_ungated_idea_never_reaches_the_board(self, client):
+        """Defence in depth: even if something scores an ungated PKI idea,
+        the board query itself must refuse to show it. This is the guarantee
+        — the generation-side exclusions are only the efficiency half."""
+        from project_forge.web.app import db as app_db
+
+        smuggled = _urgent_idea(name="Smuggled In", content_hash="smuggle-1")
+        smuggled.generation_mode = "novel"  # not the gated cadence
+        smuggled.pki_urgency_score = 0.99  # scored anyway
+        smuggled.pki_anchor = "RFC 5280"
+        await app_db.save_idea(smuggled)
+
+        page = await client.get("/pki")
+        assert "Smuggled In" not in page.text
+
+        api = await client.get("/api/pki/top?limit=50")
+        assert "Smuggled In" not in [d["name"] for d in api.json()]
+
     @pytest.mark.asyncio
     async def test_api_top_returns_only_scored_sorted(self, client):
         resp = await client.get("/api/pki/top?limit=10")
@@ -726,6 +1136,14 @@ class TestPkiRoutes:
         resp = await client.get("/pki")
         assert "Probe log" in resp.text
         assert "probed gap" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_page_shows_strongest_counterargument(self, client):
+        """The objection is surfaced, not buried — a finding that names its
+        own weakest joint is the whole product of the depth panel."""
+        resp = await client.get("/pki")
+        assert "strongest counterargument" in resp.text
+        assert "honour the IDP extension" in resp.text
 
     @pytest.mark.asyncio
     async def test_category_filter_narrows(self, client):

--- a/tests/test_pki_depth.py
+++ b/tests/test_pki_depth.py
@@ -1,0 +1,657 @@
+"""Tests for the PKI multi-pass depth engine (`engine/pki_depth.py`).
+
+The PKI board's gate is selective, but selectivity alone does not make a
+finding a CA engineer would act on — a one-shot draft can be well-anchored
+and still be wrong, or already solved by a tool the model never heard of.
+The depth engine attacks each admitted draft from three independent
+adversarial angles, kills it if the panel lands a fatal hit, and otherwise
+rewrites it to answer what survived.
+
+Covers:
+  - keyless: zero calls, idea untouched, passes=0 (the non-negotiable)
+  - the three lenses each get a genuinely distinct prompt
+  - kill conditions: a high-severity 'solved' hit, or two high-severity
+    hits across lenses
+  - the revision preserves idea identity (id / category / content_hash)
+  - unparseable or garbage revision output falls back to the original
+  - objections come back strongest-first
+  - a clean draft survives with the revision applied
+
+No test may reach a real LLM: the backend is always a MagicMock.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from project_forge.engine import pki_depth
+from project_forge.engine.pki_depth import (
+    FATAL_SEVERITY,
+    HIGH_SEVERITY,
+    LENSES,
+    OBJECTION_DISPLAY_FLOOR,
+    UNCITED_SEVERITY_CAP,
+    Objection,
+    deepen,
+)
+from project_forge.models import Idea, IdeaCategory
+
+
+def _draft(**over) -> Idea:
+    base = dict(
+        name="Delta-CRL Shard Planner",
+        tagline="partition issuing distribution points before CRLs blow the size budget",
+        description=(
+            "ML-DSA signatures push CRL size past what clients will fetch, and "
+            "operators size shards by hand today. Anchored to RFC 5280."
+        ),
+        category=IdeaCategory.PKI_REVOCATION,
+        market_analysis="Every CA hits this at the ML-DSA transition.",
+        feasibility_score=0.8,
+        mvp_scope="Phase 1: growth model. Phase 2: shard plan emitter.",
+        tech_stack=["go", "postgres"],
+        content_hash="deadbeefcafe",
+    )
+    base.update(over)
+    return Idea(**base)
+
+
+def _obj(text: str, severity: float, citation: str | None = None) -> str:
+    payload = {"objection": text, "severity": severity}
+    if citation is not None:
+        payload["citation"] = citation
+    return json.dumps(payload)
+
+
+# The `wrong` lens must cite what it is correcting, so anything that is meant
+# to land as a real hit carries one.
+def _cited(text: str, severity: float) -> str:
+    return _obj(text, severity, citation="RFC 5280 s5.2.5")
+
+
+_CLEAN_REVISION = json.dumps(
+    {
+        "name": "Delta-CRL Shard Planner",
+        "tagline": "size issuing distribution points against a hard client fetch budget",
+        "description": (
+            "Models per-shard revocation growth under ML-DSA signature sizes and emits "
+            "a partitioning plan operators can diff. Strongest counterargument: large CAs "
+            "already shard by hand, so the value is the growth model, not the partitioning."
+        ),
+        "mvp_scope": "Phase 1: growth model against real CRL corpora. Phase 2: plan emitter.",
+        "market_analysis": "Public CAs and large enterprise PKIs at the ML-DSA transition.",
+        "added_specifics": ["per-shard growth model against a real CRL corpus"],
+        "dropped_claims": ["that operators have no partitioning story at all"],
+    }
+)
+
+
+def _backend(*responses: str | None) -> MagicMock:
+    backend = MagicMock()
+    backend.call = MagicMock(side_effect=list(responses))
+    return backend
+
+
+def _use(monkeypatch, backend) -> None:
+    monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: backend)
+
+
+# --------------------------------------------------------------------------- #
+# keyless                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestKeyless:
+    @pytest.mark.asyncio
+    async def test_no_backend_returns_idea_untouched(self, monkeypatch):
+        _use(monkeypatch, None)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+        assert result.objections == []
+        assert result.strongest is None
+        assert result.survived is True
+        assert result.passes == 0
+
+    @pytest.mark.asyncio
+    async def test_no_backend_makes_no_calls(self, monkeypatch):
+        # A backend that detonates if touched — proves the keyless path never
+        # reaches for one rather than merely tolerating a failure.
+        exploding = MagicMock()
+        exploding.call = MagicMock(side_effect=AssertionError("no LLM call allowed when keyless"))
+        monkeypatch.setattr(pki_depth, "resolve_cheap_backend", lambda: None)
+        result = await deepen(_draft())
+
+        assert result.passes == 0
+        assert exploding.call.call_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# the panel                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestPanel:
+    @pytest.mark.asyncio
+    async def test_three_lenses_get_distinct_prompts(self, monkeypatch):
+        backend = _backend(
+            _obj("premise is fine", 0.1),
+            _obj("nothing does this", 0.1),
+            _obj("sizes check out", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft())
+
+        prompts = [c.args[0] for c in backend.call.call_args_list[: len(LENSES)]]
+        assert len(prompts) == 3
+        assert len(set(prompts)) == 3, "each lens must have its own prompt"
+
+    @pytest.mark.asyncio
+    async def test_four_calls_for_a_surviving_draft(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert backend.call.call_count == 4
+        assert result.passes == 4
+
+    @pytest.mark.asyncio
+    async def test_objections_sorted_strongest_first(self, monkeypatch):
+        backend = _backend(
+            _obj("weak premise nit", 0.2),
+            _obj("partially covered by certbot", 0.55),
+            _obj("wrong signature size cited", 0.4),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        sevs = [o.severity for o in result.objections]
+        assert sevs == sorted(sevs, reverse=True)
+        assert result.strongest == "partially covered by certbot"
+
+    @pytest.mark.asyncio
+    async def test_empty_objection_is_dropped(self, monkeypatch):
+        backend = _backend(
+            json.dumps({"objection": "none", "severity": 0.0}),
+            _obj("", 0.9),
+            _obj("wrong layer", 0.3),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert [o.text for o in result.objections] == ["wrong layer"]
+
+    @pytest.mark.asyncio
+    async def test_unparseable_lens_output_is_skipped_not_fatal(self, monkeypatch):
+        backend = _backend(
+            "I cannot comply with that",
+            None,
+            _obj("wrong threat model", 0.3),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is True
+        assert len(result.objections) == 1
+        assert result.objections[0].lens == "wrong"
+
+
+# --------------------------------------------------------------------------- #
+# kill conditions                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestKill:
+    @pytest.mark.asyncio
+    async def test_fatal_solved_kills_outright(self, monkeypatch):
+        backend = _backend(
+            _obj("premise holds", 0.1),
+            _obj("openssl crl -shard already does exactly this", FATAL_SEVERITY + 0.05),
+            _obj("no protocol error", 0.1),
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is False
+        assert result.passes == len(LENSES), "a killed draft is never revised"
+        assert "openssl" in (result.strongest or "")
+
+    @pytest.mark.asyncio
+    async def test_two_high_severity_across_lenses_kills(self, monkeypatch):
+        backend = _backend(
+            _obj("the mechanism is not what the draft claims", HIGH_SEVERITY + 0.1),
+            _obj("nothing solves it", 0.2),
+            _cited("cites the wrong signature sizes entirely", HIGH_SEVERITY + 0.2),
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is False
+        assert backend.call.call_count == len(LENSES)
+
+    @pytest.mark.asyncio
+    async def test_one_non_solved_high_severity_survives(self, monkeypatch):
+        backend = _backend(
+            _obj("mechanism is mischaracterized", HIGH_SEVERITY + 0.1),
+            _obj("nothing solves it", 0.2),
+            _obj("sizes fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is True
+        assert result.passes == 4
+
+    @pytest.mark.asyncio
+    async def test_solved_below_threshold_does_not_kill(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("certbot partially overlaps", HIGH_SEVERITY - 0.05),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is True
+
+    @pytest.mark.asyncio
+    async def test_partial_coverage_solved_hit_is_answerable_not_fatal(self, monkeypatch):
+        """The prompt's own rubric calls 0.7-0.9 "a problem the author must
+        answer", and the `solved` brief invites exactly the partial answer
+        that lands there. Every PKI idea has partial prior coverage; reading
+        it as unsalvageable empties the board."""
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("lego renews ACME certs, so renewal is covered", 0.8),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is True
+        assert result.passes == 4, "a survivable objection must still be answered by a rewrite"
+
+    @pytest.mark.asyncio
+    async def test_uncited_wrong_hit_cannot_vote_toward_a_kill(self, monkeypatch):
+        """An uncited factual correction is an assertion. It informs the
+        rewrite; it does not get a vote."""
+        backend = _backend(
+            _obj("the mechanism is not what the draft claims", 0.85),
+            _obj("nothing solves it", 0.2),
+            _obj("ML-DSA signatures are 2420 bytes, not 3309", 0.95),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.survived is True
+        wrong = next(o for o in result.objections if o.lens == "wrong")
+        assert wrong.severity == pytest.approx(UNCITED_SEVERITY_CAP)
+
+    @pytest.mark.asyncio
+    async def test_cited_wrong_hit_keeps_its_severity_and_its_citation(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _obj("ML-DSA-65 signatures are 3309 bytes", 0.8, citation="FIPS 204 Table 2"),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        wrong = next(o for o in result.objections if o.lens == "wrong")
+        assert wrong.severity == pytest.approx(0.8)
+        assert "FIPS 204 Table 2" in wrong.text, "the citation must survive to the operator"
+
+    @pytest.mark.asyncio
+    async def test_killed_draft_keeps_the_original_idea(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("already shipped in step-ca", 0.95),
+            _obj("fine", 0.1),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+
+
+# --------------------------------------------------------------------------- #
+# revision                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestRevision:
+    @pytest.mark.asyncio
+    async def test_revision_preserves_identity(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea.id == idea.id
+        assert result.idea.category == idea.category
+        assert result.idea.content_hash == idea.content_hash
+        assert result.idea.pki_urgency_score == idea.pki_urgency_score
+
+    @pytest.mark.asyncio
+    async def test_revision_rewrites_the_prose(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea.description != idea.description
+        assert "counterargument" in result.idea.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_revise_prompt_carries_the_surviving_objections(self, monkeypatch):
+        backend = _backend(
+            _obj("premise nit about OCSP stapling", 0.3),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft())
+
+        revise_prompt = backend.call.call_args_list[-1].args[0]
+        assert "premise nit about OCSP stapling" in revise_prompt
+
+    @pytest.mark.asyncio
+    async def test_unparseable_revision_falls_back_to_original(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            "Sure! Here is your revised idea: <not json at all>",
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+        assert result.survived is True
+        assert result.passes == 4
+
+    @pytest.mark.asyncio
+    async def test_revision_missing_fields_falls_back(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            json.dumps({"name": "Only A Name"}),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+
+    @pytest.mark.asyncio
+    async def test_revision_with_blank_field_falls_back(self, monkeypatch):
+        payload = json.loads(_CLEAN_REVISION)
+        payload["description"] = "   "
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            json.dumps(payload),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+
+    @pytest.mark.asyncio
+    async def test_fenced_revision_is_accepted(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            f"```json\n{_CLEAN_REVISION}\n```",
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea.tagline != idea.tagline
+
+    @pytest.mark.asyncio
+    async def test_unfaulted_draft_is_not_rewritten(self, monkeypatch):
+        """A rewrite with no criticism to answer has nothing to work from and
+        can only dilute a draft the panel could not fault. Three calls, not
+        four, and the draft ships as written."""
+        backend = _backend(
+            json.dumps({"objection": "none", "severity": 0.0}),
+            json.dumps({"objection": "none", "severity": 0.0}),
+            json.dumps({"objection": "none", "severity": 0.0}),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.survived is True
+        assert result.objections == []
+        assert result.strongest is None
+        assert result.idea is idea
+        assert result.passes == 3
+        assert backend.call.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_revision_declaring_no_delta_falls_back_to_the_draft(self, monkeypatch):
+        """The only checkable forcing function available: the rewrite has to
+        name what it added or what it dropped. Nothing downstream can tell
+        "sharpened the mechanism" from "changed three adjectives"."""
+        payload = json.loads(_CLEAN_REVISION)
+        payload["added_specifics"] = []
+        payload["dropped_claims"] = []
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            json.dumps(payload),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+        assert result.revised is False
+
+    @pytest.mark.asyncio
+    async def test_revision_omitting_the_delta_keys_falls_back(self, monkeypatch):
+        payload = json.loads(_CLEAN_REVISION)
+        payload.pop("added_specifics")
+        payload.pop("dropped_claims")
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            json.dumps(payload),
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+
+    @pytest.mark.asyncio
+    async def test_list_valued_mvp_scope_is_accepted(self, monkeypatch):
+        """Models routinely return phased scope as a JSON list. Discarding the
+        whole revision over the container type wastes the call."""
+        payload = json.loads(_CLEAN_REVISION)
+        payload["mvp_scope"] = ["Phase 1: growth model.", "Phase 2: plan emitter."]
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            json.dumps(payload),
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert "Phase 1: growth model." in result.idea.mvp_scope
+        assert "Phase 2: plan emitter." in result.idea.mvp_scope
+
+    @pytest.mark.asyncio
+    async def test_objection_is_withheld_when_the_rewrite_never_landed(self, monkeypatch):
+        """The card presents the objection as one the proposal answers. When
+        the rewrite failed, the text below it answers nothing."""
+        backend = _backend(
+            _obj("partitioning only helps clients that honour the IDP extension", 0.6),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            "not json at all",
+        )
+        _use(monkeypatch, backend)
+        idea = _draft()
+        result = await deepen(idea)
+
+        assert result.idea is idea
+        assert result.revised is False
+        assert result.strongest is None
+
+
+# --------------------------------------------------------------------------- #
+# misc surface                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestGrounding:
+    """The `solved` lens holds the only unilateral veto, and its question is
+    the one with external evidence available. Handing it that evidence turns
+    recall — the prompt shape that invents a plausible tool and kills real
+    work with it — into adjudication."""
+
+    _REPOS = [
+        {"name": "crlite", "stars": 900, "description": "CRL filter cascade distribution for Firefox"},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_prior_art_reaches_the_solved_lens(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft(), prior_art=self._REPOS)
+
+        solved = next(p for p in (c.args[0] for c in backend.call.call_args_list) if "ATTACK THE NOVELTY" in p)
+        assert "crlite" in solved
+        assert "900 stars" in solved
+
+    @pytest.mark.asyncio
+    async def test_prior_art_does_not_leak_into_the_other_lenses(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft(), prior_art=self._REPOS)
+
+        for prompt in (c.args[0] for c in backend.call.call_args_list):
+            if "ATTACK THE PREMISE" in prompt or "ATTACK THE CORRECTNESS" in prompt:
+                assert "crlite" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_absent_prior_art_is_not_reported_as_proof_of_novelty(self, monkeypatch):
+        backend = _backend(
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft())
+
+        solved = next(p for p in (c.args[0] for c in backend.call.call_args_list) if "ATTACK THE NOVELTY" in p)
+        assert "Do not treat this as proof of novelty" in solved
+
+    @pytest.mark.asyncio
+    async def test_revision_must_differentiate_against_named_prior_art(self, monkeypatch):
+        backend = _backend(
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _obj("minor", 0.2),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        await deepen(_draft(), prior_art=self._REPOS)
+
+        revise = backend.call.call_args_list[-1].args[0]
+        assert "crlite" in revise
+
+
+class TestSurface:
+    @pytest.mark.asyncio
+    async def test_a_nit_is_never_surfaced_as_the_strongest_counterargument(self, monkeypatch):
+        backend = _backend(
+            _obj("the tagline could be tighter", 0.05),
+            _obj("none", 0.0),
+            _obj("none", 0.0),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert result.objections, "the nit is still fed to the rewrite"
+        assert result.strongest is None, "a 0.05 quibble is not a counterargument"
+
+    def test_display_floor_sits_above_the_nit_line(self):
+        assert UNCITED_SEVERITY_CAP < OBJECTION_DISPLAY_FLOOR < HIGH_SEVERITY < FATAL_SEVERITY <= 1.0
+
+    def test_lenses_are_the_three_documented_angles(self):
+        assert LENSES == ("real", "solved", "wrong")
+
+    def test_high_severity_is_a_tunable_in_range(self):
+        assert 0.0 < HIGH_SEVERITY < 1.0
+
+    def test_objection_is_a_plain_record(self):
+        o = Objection(lens="real", severity=0.5, text="x")
+        assert (o.lens, o.severity, o.text) == ("real", 0.5, "x")
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_severity_is_clamped(self, monkeypatch):
+        backend = _backend(
+            _obj("way over", 4.2),
+            _obj("way under", -3.0),
+            _obj("fine", 0.1),
+            _CLEAN_REVISION,
+        )
+        _use(monkeypatch, backend)
+        result = await deepen(_draft())
+
+        assert all(0.0 <= o.severity <= 1.0 for o in result.objections)

--- a/tests/test_pki_prior_art.py
+++ b/tests/test_pki_prior_art.py
@@ -1,0 +1,463 @@
+"""Tests for the PKI prior-art gate.
+
+"This already exists" is the biggest killer of certificate-tooling ideas —
+there are dozens of expiry monitors, ACME clients and chain checkers. This
+gate asks GitHub whether a maintained tool already does the job, and is
+deliberately biased toward letting things through: a network blip must
+never look like "already exists".
+
+Every test injects a fake `http_get`. Nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from project_forge.engine.pki_prior_art import (
+    MATCH_THRESHOLD,
+    MAX_SEARCH_REQUESTS,
+    MAX_SEARCH_TERMS,
+    STAR_ESTABLISHED,
+    PriorArtVerdict,
+    check_prior_art,
+    clear_prior_art_cache,
+    extract_search_terms,
+    score_match,
+)
+from project_forge.models import Idea, IdeaCategory
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    clear_prior_art_cache()
+    yield
+    clear_prior_art_cache()
+
+
+def make_idea(name: str, tagline: str, **kw) -> Idea:
+    return Idea(
+        name=name,
+        tagline=tagline,
+        description=kw.pop("description", ""),
+        category=kw.pop("category", IdeaCategory.CERT_LIFECYCLE),
+        market_analysis=kw.pop("market_analysis", ""),
+        feasibility_score=kw.pop("feasibility_score", 0.7),
+        mvp_scope=kw.pop("mvp_scope", ""),
+        **kw,
+    )
+
+
+def repo(name: str, description: str, stars: int, url: str | None = None) -> dict:
+    return {
+        "name": name,
+        "url": url or f"https://github.com/example/{name}",
+        "stars": stars,
+        "description": description,
+    }
+
+
+def fake_http(payload_by_call: list, counter: list | None = None):
+    """An http_get that returns canned payloads, recording every URL."""
+    calls = counter if counter is not None else []
+
+    def _get(url: str, *, timeout: float = 15.0) -> bytes:
+        calls.append(url)
+        payload = payload_by_call[min(len(calls) - 1, len(payload_by_call) - 1)]
+        if isinstance(payload, Exception):
+            raise payload
+        if isinstance(payload, bytes):
+            return payload
+        return json.dumps(payload).encode()
+
+    _get.calls = calls  # type: ignore[attr-defined]
+    return _get
+
+
+def gh_payload(*repos: dict) -> dict:
+    return {
+        "total_count": len(repos),
+        "items": [
+            {
+                "full_name": f"example/{r['name']}",
+                "name": r["name"],
+                "html_url": r["url"],
+                "stargazers_count": r["stars"],
+                "description": r["description"],
+                "archived": False,
+            }
+            for r in repos
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Search-term extraction                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_terms_strips_generic_filler():
+    idea = make_idea(
+        "Certificate Revocation Platform",
+        "A management system and tool suite for operators",
+    )
+    joined = " ".join(extract_search_terms(idea))
+    for filler in ("platform", "system", "tool", "suite", "management"):
+        assert filler not in joined.split()
+
+
+def test_extract_terms_keeps_domain_tokens():
+    idea = make_idea("CRL Delta Distributor", "Pushes OCSP deltas to ACME issuers")
+    joined = " ".join(extract_search_terms(idea))
+    for token in ("crl", "ocsp", "acme"):
+        assert token in joined
+
+
+def test_extract_terms_prefers_specific_domain_tokens_over_broad_ones():
+    idea = make_idea(
+        "Workload Trust Bootstrapper",
+        "Bootstraps X.509 certificate trust for SPIFFE workloads from an HSM-backed TLS root",
+    )
+    joined = " ".join(extract_search_terms(idea))
+    assert "spiffe" in joined
+    assert "hsm" in joined
+
+
+def test_extract_terms_is_capped_and_nonempty():
+    idea = make_idea(
+        "CRLite Delta Distributor",
+        "Ships incremental CRLite filter deltas to embedded devices over CoAP",
+    )
+    terms = extract_search_terms(idea)
+    assert 1 <= len(terms) <= MAX_SEARCH_TERMS
+    assert all(t.strip() for t in terms)
+
+
+def test_extract_terms_on_pure_filler_name_returns_nothing_useless():
+    idea = make_idea("The Platform", "A system for the tool")
+    assert extract_search_terms(idea) == []
+
+
+# --------------------------------------------------------------------------- #
+# Match scoring                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_score_match_flags_same_job():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    hit = repo(
+        "cert-expiry-monitor",
+        "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+        stars=4200,
+    )
+    assert score_match(idea, hit) >= MATCH_THRESHOLD
+
+
+def test_score_match_ignores_merely_topical_overlap():
+    idea = make_idea(
+        "CRLite Delta Distributor",
+        "Ships incremental CRLite filter deltas to embedded devices over CoAP",
+    )
+    topical = repo(
+        "awesome-certificates",
+        "A curated list of certificate, TLS and PKI resources",
+        stars=9000,
+    )
+    assert score_match(idea, topical) < MATCH_THRESHOLD
+
+
+def test_score_match_star_weighting_spares_unmaintained_repos():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    body = "Monitors TLS certificate expiry across your fleet and alerts before renewal"
+    popular = score_match(idea, repo("cert-expiry-monitor", body, stars=STAR_ESTABLISHED * 10))
+    abandoned = score_match(idea, repo("cert-expiry-monitor", body, stars=3))
+    assert abandoned < popular
+    assert abandoned < MATCH_THRESHOLD
+
+
+def test_shared_domain_vocabulary_alone_is_never_prior_art():
+    """The failure mode that quietly empties the board: this board is
+    ENTIRELY about certificates, so `chain`, `hsm`, `ocsp` and `ceremony` are
+    the words two items share by both being PKI. Scored as purpose, two of
+    them plus a popular repo cleared the kill threshold on their own."""
+    sizer = make_idea("PQ Chain Sizer", "Model ML-DSA handshake bloat across TLS certificate chains")
+    fuzzer = repo("tlsfuzzer", "TLS protocol test suite covering handshake and chain edge cases", stars=700)
+    assert score_match(sizer, fuzzer) < MATCH_THRESHOLD
+
+    ceremony = make_idea("Ceremony Rehearsal Kit", "Rehearse root key ceremony scripts against an HSM")
+    softhsm = repo("softhsm", "A software implementation of an HSM with a PKCS#11 interface", stars=1200)
+    assert score_match(ceremony, softhsm) < MATCH_THRESHOLD
+
+
+def test_shared_job_words_still_score_over_the_same_vocabulary():
+    """The other half of the bargain: fold domain nouns into the topical
+    class and a genuine duplicate must still land."""
+    idea = make_idea(
+        "OCSP Stapling Drift Detector",
+        "Detect and alert when stapled OCSP responses drift stale across a fleet",
+    )
+    duplicate = repo(
+        "staple-drift",
+        "Detects stale stapled OCSP responses across your fleet and alerts on drift",
+        stars=1500,
+    )
+    assert score_match(idea, duplicate) >= MATCH_THRESHOLD
+
+
+def test_score_match_is_bounded():
+    idea = make_idea("Certificate Expiry Monitor", "Monitors certificate expiry and alerts on renewal")
+    hit = repo("cert-expiry-monitor", "monitor certificate expiry alerts renewal fleet", stars=99999)
+    assert 0.0 <= score_match(idea, hit) <= 1.0
+    assert score_match(idea, repo("unrelated", "a static site generator", stars=500)) == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# check_prior_art — the verdict                                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_obvious_duplicate_is_flagged():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http(
+        [
+            gh_payload(
+                repo(
+                    "cert-expiry-monitor",
+                    "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+                    stars=4200,
+                )
+            )
+        ]
+    )
+    verdict = await check_prior_art(idea, http_get=http)
+    assert isinstance(verdict, PriorArtVerdict)
+    assert verdict.exists is True
+    assert verdict.confidence >= MATCH_THRESHOLD
+    assert verdict.matches[0]["name"] == "cert-expiry-monitor"
+    assert verdict.matches[0]["stars"] == 4200
+    assert "cert-expiry-monitor" in verdict.reason
+
+
+@pytest.mark.asyncio
+async def test_novel_idea_against_topical_repo_is_not_flagged():
+    idea = make_idea(
+        "CRLite Delta Distributor",
+        "Ships incremental CRLite filter deltas to embedded devices over CoAP",
+    )
+    topical = repo("awesome-certificates", "A curated list of certificate and PKI resources", 9000)
+    http = fake_http([gh_payload(topical)])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert verdict.confidence < MATCH_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_empty_search_results_are_not_prior_art():
+    idea = make_idea("CRLite Delta Distributor", "Ships incremental CRLite filter deltas over CoAP")
+    http = fake_http([{"total_count": 0, "items": []}])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert verdict.matches == []
+
+
+@pytest.mark.asyncio
+async def test_low_star_match_does_not_kill_the_idea():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http(
+        [
+            gh_payload(
+                repo(
+                    "cert-expiry-monitor",
+                    "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+                    stars=2,
+                )
+            )
+        ]
+    )
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+
+
+@pytest.mark.asyncio
+async def test_request_count_is_capped():
+    idea = make_idea(
+        "CRL Delta Distributor",
+        "Pushes OCSP and ACME revocation deltas to HSM-backed SPIFFE workloads over CoAP",
+    )
+    http = fake_http([{"total_count": 0, "items": []}])
+    await check_prior_art(idea, http_get=http)
+    assert 1 <= len(http.calls) <= MAX_SEARCH_REQUESTS
+
+
+# --------------------------------------------------------------------------- #
+# Fail open                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_network_failure_fails_open():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http([OSError("connection refused")])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert verdict.confidence == 0.0
+    assert verdict.matches == []
+    assert "could not" in verdict.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_fails_open():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http([b"<html>502 Bad Gateway</html>"])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert "could not" in verdict.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_body_fails_open():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http([{"message": "API rate limit exceeded", "documentation_url": "https://docs.github.com"}])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert "could not" in verdict.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_still_uses_the_working_search():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    payloads = [
+        OSError("boom"),
+        gh_payload(
+            repo(
+                "cert-expiry-monitor",
+                "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+                stars=4200,
+            )
+        ),
+    ]
+    verdict = await check_prior_art(idea, http_get=fake_http(payloads))
+    assert verdict.exists is True
+
+
+@pytest.mark.asyncio
+async def test_unsearchable_idea_fails_open():
+    idea = make_idea("The Platform", "A system for the tool")
+    http = fake_http([{"total_count": 0, "items": []}])
+    verdict = await check_prior_art(idea, http_get=http)
+    assert verdict.exists is False
+    assert http.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Caching                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_repeat_check_is_served_from_cache():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    http = fake_http(
+        [
+            gh_payload(
+                repo(
+                    "cert-expiry-monitor",
+                    "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+                    stars=4200,
+                )
+            )
+        ]
+    )
+    first = await check_prior_art(idea, http_get=http)
+    fetched = len(http.calls)
+    assert fetched >= 1
+    second = await check_prior_art(idea, http_get=http)
+    assert len(http.calls) == fetched  # no re-fetch
+    assert second.exists == first.exists
+    assert second.confidence == pytest.approx(first.confidence)
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_forces_refetch():
+    idea = make_idea("CRLite Delta Distributor", "Ships incremental CRLite filter deltas over CoAP")
+    http = fake_http([{"total_count": 0, "items": []}])
+    await check_prior_art(idea, http_get=http)
+    fetched = len(http.calls)
+    clear_prior_art_cache()
+    await check_prior_art(idea, http_get=http)
+    assert len(http.calls) > fetched
+
+
+@pytest.mark.asyncio
+async def test_cache_is_bounded():
+    """uvicorn processes live for weeks. An unbounded per-term dict also pins
+    a stale empty result for a term forever."""
+    from project_forge.engine import pki_prior_art
+
+    http = fake_http([{"total_count": 0, "items": []}])
+    for n in range(pki_prior_art.MAX_CACHE_ENTRIES + 20):
+        await pki_prior_art._search(f"crl shard term{n}", http)
+    assert len(pki_prior_art._SEARCH_CACHE) <= pki_prior_art.MAX_CACHE_ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_failed_search_is_not_cached():
+    idea = make_idea(
+        "Certificate Expiry Monitor",
+        "Monitors certificate expiry across a fleet and alerts before renewal",
+    )
+    calls: list[str] = []
+    payloads = [
+        OSError("boom"),
+        gh_payload(
+            repo(
+                "cert-expiry-monitor",
+                "Monitors TLS certificate expiry across your fleet and alerts before renewal",
+                stars=4200,
+            )
+        ),
+    ]
+    seq = {"i": 0}
+
+    def _get(url: str, *, timeout: float = 15.0) -> bytes:
+        calls.append(url)
+        payload = payloads[0] if seq["i"] == 0 else payloads[1]
+        seq["i"] += 1
+        if isinstance(payload, Exception):
+            raise payload
+        return json.dumps(payload).encode()
+
+    first = await check_prior_art(idea, http_get=_get)
+    assert first.exists is False or first.exists is True  # verdict irrelevant here
+    before = len(calls)
+    await check_prior_art(idea, http_get=_get)
+    assert len(calls) > before  # the failed term was retried, not cached


### PR DESCRIPTION
## Summary

Three changes so `/pki` actually means what it claims.

## 1. Multi-pass depth

Each candidate now survives a three-lens adversarial panel before landing — `real` (is the problem real, is the mechanism right), `solved` (does existing tooling cover this), `wrong` (protocol error, wrong sizes, wrong layer, misread spec) — then a revise pass rewrites it to answer the surviving objections. The strongest remaining counterargument is stored and shown on the card.

4 LLM calls per admitted item. Correct trade on a board admitting ~1 item per several hours. Keyless-safe: no backend → zero calls, idea returned untouched.

## 2. Prior-art gate

Fourth rejection reason. Keyless GitHub search weighted by stars, run **before** the panel so a duplicate costs 3 HTTP calls instead of 5 LLM calls. **Fails open** on every failure path — a network blip must never silently empty the board.

## 3. The back door

The board shipped with a hard gate on its own cadence while the ordinary rotation kept generating into the same five categories. A *score* is what puts an idea on `/pki`, and the back-fill scored whatever it found:

```
ON THE BOARD           :  77
    49  generation_mode='pki'   <- through the gate
    28  template/novel/...      <- never gated

queued behind the back-fill: 201
```

On track to be ~80% ungated while advertising selectivity. Fixed on both sides:

- **Guarantee** — `/pki` and `/api/pki/top` filter on `generation_mode='pki'`; the back-fill is scoped the same way. Nothing ungated appears even if something else scores it.
- **Efficiency** — new `GATED_CATEGORIES`, excluded from the general rotation, the template generator, and super-idea pairing.

A one-shot purge cleared 50 ungated rows: **board 69 → 47, all gated**, nothing deleted (242 PKI ideas remain in the pool via `/explore`). The purged names show the problem plainly — *"Offline Root Air-gap Workflow for Identity"*, *"Ct Log Inclusion-proof Verifier for Trust-store"*: seed concepts slot-filled with a domain noun.

## Evidence the panel is working

10 of 12 candidates killed since going live. Spot-checking says it's being *correct*, not merely harsh:

> *"TLSA 3 1 1 pins the SPKI, not the certificate, so cutting cert lifetimes to 47 or 6 days generates zero additional TLSA rollovers when the key is reused across renewals."*

Selector `1` is SubjectPublicKeyInfo, so that's right. The draft had pitched "shorter certs break DANE" — sounds right, isn't.

Admission rate: **63%** (anchor+urgency) → **0%** (with the panel). That rate is the open question; thresholds remain uncalibrated.

## Review caught two board-emptying bugs

Both would have looked correct while failing:

1. Prior-art scored shared domain nouns (`ocsp`, `crl`, `acme`) as *purpose* tokens — two of them plus a popular repo cleared the threshold. Verified fix against the documented false kills: OCSP Stapling Drift Detector vs `ocsp-stapling-check` went 0.560 (killed) → 0.000 (survives); a genuine duplicate still dies at 0.960.
2. The panel killed on severity 0.70 while the prompt told the model 0.70 meant "answerable". Fatal now 0.90, matching the rubric.

Also fixed: `deepen()` ran four synchronous subprocess calls on the event loop (now `asyncio.to_thread`); the exception path was the one exit recording no probe, which would have pinned the cadence to a failing gap forever.

## Verification

- **1942 passed, 1 skipped**
- `ruff check` + `ruff format --check` clean
- Live board confirmed: 47 items, `generation_mode` set is exactly `{'pki'}`
- Migration confirmed on the production DB

## Note

`cron/scheduler.py` carries a small pre-existing uncommitted tweak (richer anti-similarity context) that was already in the working tree; it rides along because this commit edits the same file.

Generated with Claude Code